### PR TITLE
Add pagination documentation

### DIFF
--- a/content/01-introduction.md
+++ b/content/01-introduction.md
@@ -1,18 +1,18 @@
 ## Cadasta API documentation
 
-Welcome to the Cadasta Platform API documentation. 
+Welcome to the Cadasta Platform API documentation.
 
-Using this platform API, you can: 
+Using this platform API, you can:
 
-* Manage user [accounts](#managing-a-user-account) - creating them, deleting them, and amending them as needed; 
-* Create and edit [organizations](#organizations); 
-* View, create, and modify [projects](#projects) in the system, 
+* Manage user [accounts](#managing-a-user-account) - creating them, deleting them, and amending them as needed;
+* Create and edit [organizations](#organizations);
+* View, create, and modify [projects](#projects) in the system,
 * Upload new [questionnaires](#questionnaires-1),
-* Add, modify and delete records for: 
-  * [spatial units/project locations](#spatial-units-aka-project-locations), 
-  * [parties](#parties) associated with these locations, and
-  * the [relationships](#relationships) between the two. 
-* And finally add, modify, and delete [project resources](#project-resources). 
+* Add, modify and delete records for:
+* [spatial units/project locations](#spatial-units-aka-project-locations),
+* [parties](#parties) associated with these locations, and
+* the [relationships](#relationships) between the two.
+* And finally add, modify, and delete [project resources](#project-resources).
 
 Each of the sections listed above outline how to use API endpoints to make these things happen.
 
@@ -20,7 +20,7 @@ Each of the sections listed above outline how to use API endpoints to make these
 
 ### Reading this Documentation
 
-This documentation is structured primarily by related functionality and topic, and then by endpoint. 
+This documentation is structured primarily by related functionality and topic, and then by endpoint.
 
 Each endpoint is described using several parts:
 
@@ -30,19 +30,19 @@ Each endpoint is described using several parts:
 
 * **Any URL parameters**, a.k.a. parts of the endpoints are wrapped in brackets. In the above path, those would be `{organization_slug}` and `{project_slug}`
 
-In addition, each combination of method and endpoint is described by a request payload, properties, and an example response. 
+In addition, each combination of method and endpoint is described by a request payload, properties, and an example response.
 
-All URLs referenced here require their own base path, which may be your own local instance of the Cadasta Platform. If you'd like to use an existing base path to explore the API, you can use the one for our demo site: `https://demo.cadasta.org/`. 
+All URLs referenced here require their own base path, which may be your own local instance of the Cadasta Platform. If you'd like to use an existing base path to explore the API, you can use the one for our demo site: `https://demo.cadasta.org/`.
 
 ### Using the API
 
-This API works best in one of two scenarios: 
+This API works best in one of two scenarios:
 
-1. **You're a developer working with an individual or organization using the Cadasta Platform.** If you have administrator access to the organization you're working for, you'll be able to perform many of the key functions for that organization using your [authorization token](#log-a-user-in--get-authorization-key). 
+1. **You're a developer working with an individual or organization using the Cadasta Platform.** If you have administrator access to the organization you're working for, you'll be able to perform many of the key functions for that organization using your [authorization token](#log-a-user-in--get-authorization-key).
 
-2. **You've created a locally-hosted version of the platform.** 
+2. **You've created a locally-hosted version of the platform.**
 
-If you have any questions about using the API, please don't hesitate to <a href="(http://cadasta.org/contact/)" target="_blank">contact us</a>. 
+If you have any questions about using the API, please don't hesitate to <a href="(http://cadasta.org/contact/)" target="_blank">contact us</a>.
 
 ### Requests
 
@@ -50,30 +50,30 @@ All requests are encoded in `application/json`, unless they involve some kind of
 
 ### Common Response Codes
 
-After submitting any API request, you'll get one of the following responses. 
+After submitting any API request, you'll get one of the following responses.
 
-Property | Description
+Response | Description
 ---|---
-`200` | The operation has been completed successfully
-`400` | There was a problem with the request payload. Usually this means required attributes are missing or the values provided are not accepted. Only applies the `POST`, `PATCH` and `PUT` requests. 
-`401` | This request requires a user to be authenticated. You either have not provided an authentication token or the  authentication token provided is not valid. 
-`403` | Permission denied, the user has no permission to access this resource or perform this action. 
+`200` | The operation has been completed successfully.
+`400` | There was a problem with the request payload. Usually this means required attributes are missing or the values provided are not accepted. Only applies the `POST`, `PATCH` and `PUT` requests.
+`401` | This request requires a user to be authenticated. You either have not provided an authentication token or the  authentication token provided is not valid.
+`403` | Permission denied, the user has no permission to access this resource or perform this action.
 `404` | Not found. (The object with the given slug or ID was not in the database.)
 
 ### Formatting URLs for Accessing Specific Objects
 
-To get, create, or modify projects, organizations, organization members and more, you'll need to access certain IDs (such as `username`) or a couple different kinds of slugs.  
+To get, create, or modify projects, organizations, organization members and more, you'll need to access certain IDs (such as `username`) or a couple different kinds of slugs.
 
-Two slugs that appear frequently are: 
+Two slugs that appear frequently are:
 
-* `organization_slug`, and 
+* `organization_slug`, and
 * `project_slug`
 
-You can find the `organization_slug` by locating the organization in the [list of all organizations](#list-organizations) and then copying the value of the `slug` property. 
+You can find the `organization_slug` by locating the organization in the [list of all organizations](#list-organizations) and then copying the value of the `slug` property.
 
-You can find most `project_slugs` by [viewing all of the projects in the Cadasta system](#list-all-projects), which returns publicly viewable projects as well as projects you have access to. If it's a private project, you must have access to it and find it by [listing all of the projects in an organization](#list-all-projects). 
+You can find most `project_slugs` by [viewing all of the projects in the Cadasta system](#list-all-projects), which returns publicly viewable projects as well as projects you have access to. If it's a private project, you must have access to it and find it by [listing all of the projects in an organization](#list-all-projects).
 
-Once you get your slugs, add them to your endpoint outside of the curly braces. 
+Once you get your slugs, add them to your endpoint outside of the curly braces.
 
 For example, to get at a specific project, you need to use the following endpoint:
 
@@ -87,4 +87,47 @@ If the `organization_slug` is `sample-organization` and the `project_slug` is `s
 GET /api/v1/organizations/sample-organization/projects/sample-project/
 ```
 
-This API uses many other IDs and slugs, each of which are explained along with the endpoint they are used in. 
+This API uses many other IDs and slugs, each of which are explained along with the endpoint they are used in.
+
+### Pagination
+
+When listing multiple resources, responses are paginated. This allows the server to return large datasets over a number of requests, avoiding timeouts and enabling clients to reduce wait time by making multiple requests in parallel.
+
+Paginated responses contain the following properties:
+
+Response | Description
+---|---
+`count` | Total number of resources to be returned.
+`next` | URL to next page of data (`null` if not applicable)
+`previous` | URL to previous page of data (`null` if not applicable)
+`results` | Array of resources that fit within the given page of data. _Note: GeoJSON responses return a single object with a `"type": "FeatureCollection"` and data in the `"features"` property._
+
+Pagination can be controlled with the following query parameters:
+
+Query Paramter | Description
+---|---
+`limit` | The maximum number of items to return. By default, endpoints return `100` entries per page. Any exceptions are indicated in the documentation.
+`offset` | The starting position of the query in relation to the complete set of unpaginated items.
+
+#### JSON Response
+```json
+{
+  "count": 0,
+  "next": null,
+  "previous": null,
+  "results": []
+}
+```
+
+#### GeoJSON Response
+```json
+{
+  "count": 0,
+  "next": null,
+  "previous": null,
+  "results": {
+    "type": "FeatureCollection",
+    "features": []
+  }
+}
+```

--- a/content/01-introduction.md
+++ b/content/01-introduction.md
@@ -9,9 +9,9 @@ Using this platform API, you can:
 * View, create, and modify [projects](#projects) in the system,
 * Upload new [questionnaires](#questionnaires-1),
 * Add, modify and delete records for:
-* [spatial units/project locations](#spatial-units-aka-project-locations),
-* [parties](#parties) associated with these locations, and
-* the [relationships](#relationships) between the two.
+  * [spatial units/project locations](#spatial-units-aka-project-locations),
+  * [parties](#parties) associated with these locations, and
+  * the [relationships](#relationships) between the two.
 * And finally add, modify, and delete [project resources](#project-resources).
 
 Each of the sections listed above outline how to use API endpoints to make these things happen.

--- a/content/02-users.md
+++ b/content/02-users.md
@@ -1,6 +1,6 @@
 ## Managing a User Account
 
-People who want to do more than view publicly available organizations and projects, individuals who use the Cadasta Platform are required to <a href="https://docs.cadasta.org/en/01-gettingstarted.html#createnewaccount" target="_blank">set up a user account</a>. 
+People who want to do more than view publicly available organizations and projects, individuals who use the Cadasta Platform are required to <a href="https://docs.cadasta.org/en/01-gettingstarted.html#createnewaccount" target="_blank">set up a user account</a>.
 
 You can use the Cadasta API to manage these accounts, provided that you have their username and password. This section outlines how to do that, focusing on endpoints that start with `api/v1/account/`.
 
@@ -20,11 +20,11 @@ Property | Type Description
 
 ```json
 {
-    "username": "janedoe",
-    "full_name": "Jane Doe",
-    "email": "jane@cadasta.org",
-    "email_verified": true,
-    "last_login": "2016-10-25T20:20:14.192918Z"
+  "username": "janedoe",
+  "full_name": "Jane Doe",
+  "email": "jane@cadasta.org",
+  "email_verified": true,
+  "last_login": "2016-10-25T20:20:14.192918Z"
 }
 ```
 
@@ -73,7 +73,7 @@ Property | Type | Description
 
 
 
-### Log a User Out 
+### Log a User Out
 
 ```endpoint
 POST /api/v1/account/logout/
@@ -124,10 +124,10 @@ The response contains an [account JSON object](#account-object).
 
 ```json
 {
-    "username": "j_smith",
-    "full_name": "Joe Smith",
-    "email": "joe.smith@example.com",
-    "email_verified": false
+  "username": "j_smith",
+  "full_name": "Joe Smith",
+  "email": "joe.smith@example.com",
+  "email_verified": false
 }
 ```
 
@@ -152,11 +152,11 @@ The response contains an [account JSON object](#account-object).
 
 ```json
 {
-    "username": "j_smith",
-    "full_name": "Joe Smith",
-    "email": "joe.smith@example.com",
-    "email_verified": false
-    "last_login": "2016-10-20T19:20:27.848272Z"
+  "username": "j_smith",
+  "full_name": "Joe Smith",
+  "email": "joe.smith@example.com",
+  "email_verified": false,
+  "last_login": "2016-10-20T19:20:27.848272Z"
 }
 ```
 
@@ -192,11 +192,11 @@ The response contains an [account JSON object](#account-object).
 
 ```json
 {
-    "username": "j_smith",
-    "full_name": "Joe Smith",
-    "email": "joe.smith@example.com",
-    "email_verified": false,
-    "last_login": "2016-10-20T19:20:27.848272Z"
+  "username": "j_smith",
+  "full_name": "Joe Smith",
+  "email": "joe.smith@example.com",
+  "email_verified": false,
+  "last_login": "2016-10-20T19:20:27.848272Z"
 }
 ```
 
@@ -224,11 +224,11 @@ Property | Type | Required? | Description
 ---|---|:---:|---
 `new_password` | `String` | x | The new password.
 `re_new_password` | `String` | x | A confirmation of the new password.
-`current_password` | `String` | x | The current password. 
+`current_password` | `String` | x | The current password.
 
 **Response**
 
-If the password was changed successfully, an empty response with response code `200` is returned. 
+If the password was changed successfully, an empty response with response code `200` is returned.
 
 
 
@@ -244,7 +244,7 @@ If the password was changed successfully, an empty response with response code `
 
 This section refers to endpoints that begin with `/api/v1/users/`.
 
-These endpoints are for use by superusers only – individuals who have special account access for an instance of of the Cadasta Platform. They can be used as an entry point to see all users in the platform. 
+These endpoints are for use by superusers only – individuals who have special account access for an instance of of the Cadasta Platform. They can be used as an entry point to see all users in the platform.
 
 ### Platform user response object
 
@@ -256,7 +256,7 @@ Property | Type Description
 `full_name` |  `String` | The user's full name.
 `email` |  `String` | The user's email associated with their account. Must be valid email address.
 `organizations` |  `Array` | An array of organizations the user is a member of. (See the `organizations` object table below for more information).
-`last_login` | `String` | Date and time of last user login. 
+`last_login` | `String` | Date and time of last user login.
 `is_active`| `Boolean` | Whether or not the user is active.
 
 The `organizations` object contains the following properties:
@@ -270,18 +270,18 @@ Property | Type | Description
 
 ```json
 {
-    "username": "janesmith",
-    "full_name": "Jane Smith",
-    "email": "j.smith@example.com",
-    "last_login": "2016-10-20T19:20:27.848272Z",
-    "is_active": true,
-    "organizations": [{
-        "id": "90ush89adh89shd89sah89sah",
-        "name": "Cadasta"
-    }, {
-        "id": "kxzncjkxhziuhsaiojdioasjd",
-        "name": "Foo Corp."
-    }]
+  "username": "janesmith",
+  "full_name": "Jane Smith",
+  "email": "j.smith@example.com",
+  "last_login": "2016-10-20T19:20:27.848272Z",
+  "is_active": true,
+  "organizations": [{
+    "id": "90ush89adh89shd89sah89sah",
+    "name": "Cadasta"
+  }, {
+    "id": "kxzncjkxhziuhsaiojdioasjd",
+    "name": "Foo Corp."
+  }]
 }
 ```
 
@@ -296,7 +296,7 @@ Property | Type | Description
 ```endpoint
 GET /api/v1/users/
 ```
-This method and endpoint return all of the users in the platform. 
+This method and endpoint return all of the users in the platform.
 
 **Response**
 
@@ -305,23 +305,28 @@ The response contains a [list of user JSON objects](#platform-user-response-obje
 #### Example Response
 
 ```json
-[
+{
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
     {
-        "username": "janesmith",
-        "full_name": "Jane Smith",
-        "email": "j.smith@example.com",
-        "last_login": "2016-10-20T19:20:27.848272Z",
-        "is_active": true,
-        "organizations": [{
-            "id": "90ush89adh89shd89sah89sah",
-            "name": "Cadasta"
-        }, {
-            "id": "kxzncjkxhziuhsaiojdioasjd",
-            "name": "Foo Corp."
-        }]
+      "username": "janesmith",
+      "full_name": "Jane Smith",
+      "email": "j.smith@example.com",
+      "last_login": "2016-10-20T19:20:27.848272Z",
+      "is_active": true,
+      "organizations": [{
+        "id": "90ush89adh89shd89sah89sah",
+        "name": "Cadasta"
+      }, {
+        "id": "kxzncjkxhziuhsaiojdioasjd",
+        "name": "Foo Corp."
+      }]
     }
-]
-``` 
+  ]
+}
+```
 
 
 
@@ -333,7 +338,7 @@ The response contains a [list of user JSON objects](#platform-user-response-obje
 
 ### Get a Platform User
 
-Use this method to view a single user in the platform. 
+Use this method to view a single user in the platform.
 
 ```endpoint
 GET /api/v1/users/{username}/
@@ -348,18 +353,18 @@ The response contains a [user JSON object](#platform-user-response-object), incl
 
 ```json
 {
-    "username": "janesmith",
-    "full_name": "Jane Smith",
-    "email": "j.smith@example.com",
-    "last_login": "2016-10-20T19:20:27.848272Z",
-    "is_active": true,
-    "organizations": [{
-        "id": "90ush89adh89shd89sah89sah",
-        "name": "Cadasta"
-    }, {
-        "id": "kxzncjkxhziuhsaiojdioasjd",
-        "name": "Foo Corp."
-    }]
+  "username": "janesmith",
+  "full_name": "Jane Smith",
+  "email": "j.smith@example.com",
+  "last_login": "2016-10-20T19:20:27.848272Z",
+  "is_active": true,
+  "organizations": [{
+    "id": "90ush89adh89shd89sah89sah",
+    "name": "Cadasta"
+  }, {
+    "id": "kxzncjkxhziuhsaiojdioasjd",
+    "name": "Foo Corp."
+  }]
 }
 ```
 
@@ -378,7 +383,7 @@ Use this method and endpoint to update some of the fields associated with a spec
 
 **Request Payload**
 
-All fields are optional, if a field is not present in the request payload, that field will not be updated. 
+All fields are optional, if a field is not present in the request payload, that field will not be updated.
 
 Property | Type | Required? | Description
 ---|---|:---:|---
@@ -395,18 +400,18 @@ The response contains a [user JSON object](#platform-user-response-object) that 
 
 ```json
 {
-    "username": "janesmith",
-    "full_name": "Jane Smith",
-    "email": "j.smith@example.com",
-    "last_login": "2016-10-20T19:20:27.848272Z",
-    "is_active": true,
-    "organizations": [{
-        "id": "90ush89adh89shd89sah89sah",
-        "name": "Cadasta"
-    }, {
-        "id": "kxzncjkxhziuhsaiojdioasjd",
-        "name": "Foo Corp."
-    }]
+  "username": "janesmith",
+  "full_name": "Jane Smith",
+  "email": "j.smith@example.com",
+  "last_login": "2016-10-20T19:20:27.848272Z",
+  "is_active": true,
+  "organizations": [{
+    "id": "90ush89adh89shd89sah89sah",
+    "name": "Cadasta"
+  }, {
+    "id": "kxzncjkxhziuhsaiojdioasjd",
+    "name": "Foo Corp."
+  }]
 }
 ```
 

--- a/content/03-organization.md
+++ b/content/03-organization.md
@@ -64,37 +64,42 @@ The response body is an array containing an [organization JSON object](#organiza
 #### Example response
 
 ```json
-[
-  {
-    "id": "C9nWLc9znHQ5V0aaX1tmZQoN",
-    "slug": "cadasta",
-    "name": "Cadasta",
-    "description": "",
-    "archived": true,
-    "urls": [],
-    "contacts": []
-  },
-  {
-    "id": "wS3Mp76Spqu9A0Crg9bMxB2o",
-    "slug": "david-org",
-    "name": "David Org",
-    "description": "David Org (testing)",
-    "archived": false,
-    "urls": [],
-    "contacts": [
-      {
-        "tel": null,
-        "name": "David",
-        "email": "david@example.com"
-      },
-      {
-        "tel": null,
-        "name": "Frank",
-        "email": "frank@example.com"
-      }
-    ]
-  }
-]
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": "C9nWLc9znHQ5V0aaX1tmZQoN",
+      "slug": "cadasta",
+      "name": "Cadasta",
+      "description": "",
+      "archived": true,
+      "urls": [],
+      "contacts": []
+    },
+    {
+      "id": "wS3Mp76Spqu9A0Crg9bMxB2o",
+      "slug": "david-org",
+      "name": "David Org",
+      "description": "David Org (testing)",
+      "archived": false,
+      "urls": [],
+      "contacts": [
+        {
+          "tel": null,
+          "name": "David",
+          "email": "david@example.com"
+        },
+        {
+          "tel": null,
+          "name": "Frank",
+          "email": "frank@example.com"
+        }
+      ]
+    }
+  ]
+}
 ```
 
 
@@ -106,7 +111,7 @@ The response body is an array containing an [organization JSON object](#organiza
 GET /api/v1/organizations/?permissions={permission[,permission]}
 ```
 
-Using the `permissions` query parameter, the list of organizations can be filtered according to the permissions the authenticated user has on the individual organization. 
+Using the `permissions` query parameter, the list of organizations can be filtered according to the permissions the authenticated user has on the individual organization.
 
 If you want to list only organizations where the user can create projects, you request:
 
@@ -146,37 +151,42 @@ The response body is an array containing an [organization JSON object](#organiza
 #### Example response
 
 ```json
-[
-  {
-    "id": "C9nWLc9znHQ5V0aaX1tmZQoN",
-    "slug": "cadasta",
-    "name": "Cadasta",
-    "description": "",
-    "archived": true,
-    "urls": [],
-    "contacts": []
-  },
-  {
-    "id": "wS3Mp76Spqu9A0Crg9bMxB2o",
-    "slug": "david-org",
-    "name": "David Org",
-    "description": "David Org (testing)",
-    "archived": false,
-    "urls": [],
-    "contacts": [
-      {
-        "tel": null,
-        "name": "David",
-        "email": "david@example.com"
-      },
-      {
-        "tel": null,
-        "name": "Frank",
-        "email": "frank@example.com"
-      }
-    ]
-  }
-]
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "id": "C9nWLc9znHQ5V0aaX1tmZQoN",
+      "slug": "cadasta",
+      "name": "Cadasta",
+      "description": "",
+      "archived": true,
+      "urls": [],
+      "contacts": []
+    },
+    {
+      "id": "wS3Mp76Spqu9A0Crg9bMxB2o",
+      "slug": "david-org",
+      "name": "David Org",
+      "description": "David Org (testing)",
+      "archived": false,
+      "urls": [],
+      "contacts": [
+        {
+          "tel": null,
+          "name": "David",
+          "email": "david@example.com"
+        },
+        {
+          "tel": null,
+          "name": "Frank",
+          "email": "frank@example.com"
+        }
+      ]
+    }
+  ]
+}
 ```
 
 
@@ -218,7 +228,7 @@ Here's how you need to format your contacts:
     "name": "Orion",
     "email": "orion@example.org",
     "tel": ""
-  }, 
+  },
   {
     "name": "Archimedes",
     "email": "archimedes@example.org",
@@ -277,7 +287,7 @@ The response also contains the field `users`, which provides a list of members o
 GET /api/v1/organizations/{organization_slug}/
 ```
 
-This method gets at a specific organization. 
+This method gets at a specific organization.
 
 **URL Parameters**
 
@@ -333,7 +343,7 @@ The response also contains the field `users`, which provides a list of members o
 PATCH /api/v1/organizations/{organization_slug}/
 ```
 
-This method allows you to update an organization. 
+This method allows you to update an organization.
 
 **URL Parameters**
 
@@ -345,13 +355,13 @@ URL Parameter | Description
 
 The request payload is a JSON object containing the following properties. All properties are optional — if a property is not presented the request payload, the property will not be updated.
 
-| Property | Type | Required? | Description 
-| --- | --- | --- | --- 
-| `name` | `String` |  | The name of the organization. 
-| `description` | `String` |  | A long-form description of the organization. 
-| `archived` | `Boolean` |  | Indicates whether the organization has been archived. 
-| `urls` | `Array` |  | A list of URLs to websites of this organization. 
-| `contacts` | `Array` |  | A list of contacts for this organization. A contact is a JSON object containing `name`, `email` \(optional\) and `tel` \(optional\); either `email` or `tel` must be provided. 
+| Property | Type | Required? | Description
+| --- | --- | --- | ---
+| `name` | `String` |  | The name of the organization.
+| `description` | `String` |  | A long-form description of the organization.
+| `archived` | `Boolean` |  | Indicates whether the organization has been archived.
+| `urls` | `Array` |  | A list of URLs to websites of this organization.
+| `contacts` | `Array` |  | A list of contacts for this organization. A contact is a JSON object containing `name`, `email` \(optional\) and `tel` \(optional\); either `email` or `tel` must be provided.
 
 **Response**
 
@@ -423,13 +433,13 @@ Property | Type | Description
 #### Example Member JSON Object
 
 ```json
-{ 
-    "username": "Joyce", 
-    "full_name": "Joyce Jones", 
-    "email": "joyce@example.org", 
-    "email_verified": true, 
-    "last_login": "2016-10-21T23:18:45.135341Z", 
-    "admin": true 
+{
+    "username": "Joyce",
+    "full_name": "Joyce Jones",
+    "email": "joyce@example.org",
+    "email_verified": true,
+    "last_login": "2016-10-21T23:18:45.135341Z",
+    "admin": true
 }
 ```
 
@@ -458,43 +468,27 @@ The response body is an array containing an [organization JSON object](#organiza
 #### Example Response
 
 ```json
-[
 {
-  "id": "wS3Mp76Spqu9A0Crg9bMxB2o",
-  "slug": "david-org",
-  "name": "David Org",
-  "description": "David Org (testing)",
-  "archived": false,
-  "urls": [],
-  "contacts": [
-     {
-         "tel": null,
-         "name": "David",
-         "email": "david@example.org"
-     },
-     {
-         "tel": null,
-         "name": "Frank",
-         "email": "frank@example.org"
-     }
-     ],
- "users": [
-     {
-         "username": "Kate",
-         "full_name": "Kate",
-         "email": "kate@example.org",
-         "email_verified": false,
-         "last_login": "2016-07-15T00:01:29.446812Z"
-     }
-     {
-         "username": "Beth",
-         "full_name": "Beth",
-         "email": "beth@example.org",
-         "email_verified": true,
-         "last_login": "2016-04-17T00:01:29.446812Z"
-     }
-   ]
-}]
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+       "username": "Kate",
+       "full_name": "Kate",
+       "email": "kate@example.org",
+       "email_verified": false,
+       "last_login": "2016-07-15T00:01:29.446812Z"
+    }
+    {
+       "username": "Beth",
+       "full_name": "Beth",
+       "email": "beth@example.org",
+       "email_verified": true,
+       "last_login": "2016-04-17T00:01:29.446812Z"
+    }
+  ]
+}
 ```
 
 
@@ -507,7 +501,7 @@ The response body is an array containing an [organization JSON object](#organiza
 POST /api/v1/organizations/{organization_slug}/users/
 ```
 
-This method adds a member to the organization. Note that the person needs to have an account for this to work. 
+This method adds a member to the organization. Note that the person needs to have an account for this to work.
 
 **URL Parameters**
 
@@ -524,7 +518,7 @@ Property | Type | Required? | Description
 
 **Response**
 
-The response is an [organization member JSON object](#organization-member-json-object). 
+The response is an [organization member JSON object](#organization-member-json-object).
 
 #### Example Response
 
@@ -548,7 +542,7 @@ The response is an [organization member JSON object](#organization-member-json-o
 ```endpoint
 GET /api/v1/organizations/{organization_slug}/users/{username}/
 ```
-This method gets the information of a specific member of an organization. This can be helpful if you need to see whether that person is an administrator of the organization or not. 
+This method gets the information of a specific member of an organization. This can be helpful if you need to see whether that person is an administrator of the organization or not.
 
 **URL Parameters**
 
@@ -559,7 +553,7 @@ URL Parameter | Description
 
 **Response**
 
-The response includes the properties of an [organization member JSON object](#organization-member-json-object). 
+The response includes the properties of an [organization member JSON object](#organization-member-json-object).
 
 
 #### Example Response
@@ -584,7 +578,7 @@ The response includes the properties of an [organization member JSON object](#or
 PATCH /api/v1/organizations/{organization_slug}/users/{username}/
 ```
 
-This method updates the admin status of a specific member of an organization. If you need to change the user's account information, see how to [update a user account](#update-a-user-account). 
+This method updates the admin status of a specific member of an organization. If you need to change the user's account information, see how to [update a user account](#update-a-user-account).
 
 **URL Parameters**
 
@@ -595,7 +589,7 @@ URL Parameter | Description
 
 **Request Payload**
 
-You must provide the username and the admin status. 
+You must provide the username and the admin status.
 
 Property | Type | Required? | Description
 ---|---|:---:|---
@@ -603,7 +597,7 @@ Property | Type | Required? | Description
 
 **Response**
 
-The response is an [organization member JSON object](#organization-member-json-object). 
+The response is an [organization member JSON object](#organization-member-json-object).
 
 #### Example Response
 
@@ -638,4 +632,4 @@ URL Parameter | Description
 
 **Response**
 
-If the user was successfully deleted, an empty response with status code `204` will be returned. 
+If the user was successfully deleted, an empty response with status code `204` will be returned.

--- a/content/04-project.md
+++ b/content/04-project.md
@@ -1,6 +1,6 @@
 ## Projects
 
-The Cadasta API allows you work with data for <a href="https://docs.cadasta.org/en/03-projects.html" target="_blank">projects</a> that have been added to the platform. 
+The Cadasta API allows you work with data for <a href="https://docs.cadasta.org/en/03-projects.html" target="_blank">projects</a> that have been added to the platform.
 
 ### Project JSON Object
 
@@ -35,27 +35,27 @@ Property | Type | Description
     "description": "Example Organization is a non-profit, non-governmental organization working to empower poor and marginalized individuals and communities.",
     "archived": false,
     "extent": {
-        "type": "Polygon",
-        "coordinates": [
-            [
-                [
-                    -0.17329216003417966,
-                    51.51194758264939
-                ],
-                [
-                    -0.17303466796874997,
-                    51.511092905004745
-                ],
-                [
-                    -0.1709747314453125,
-                    51.51023821132554
-                ],
-                [
-                    -0.17329216003417966,
-                    51.51194758264939
-                ]
-            ]
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -0.17329216003417966,
+            51.51194758264939
+          ],
+          [
+            -0.17303466796874997,
+            51.511092905004745
+          ],
+          [
+            -0.1709747314453125,
+            51.51023821132554
+          ],
+          [
+            -0.17329216003417966,
+            51.51194758264939
+          ]
         ]
+      ]
     },
     "urls": [
       "http://www.example.org/"
@@ -71,15 +71,16 @@ Property | Type | Description
         "name": "Megan Jones",
         "email": "megan@example.org"
       }
-  ],
-  "country": "NG",
-  "name": "Lagos Tenure Assessment (old)",
-  "description": "Security of Tenure Profiling in Lagos",
-  "archived": false,
-  "urls": [],
-  "contacts": [],
-  "access": "public",
-  "slug": "lagos-tenure-assessment"
+    ],
+    "country": "NG",
+    "name": "Lagos Tenure Assessment (old)",
+    "description": "Security of Tenure Profiling in Lagos",
+    "archived": false,
+    "urls": [],
+    "contacts": [],
+    "access": "public",
+    "slug": "lagos-tenure-assessment"
+  }
 }
 ```
 
@@ -96,7 +97,7 @@ Property | Type | Description
 
 
 
-### List All Projects 
+### List All Projects
 
 ```endpoint
 GET /api/v1/projects/
@@ -112,77 +113,81 @@ The response body is an array containing multiple [project JSON objects](#projec
 #### Example Response
 
 ```json
-[
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
     {
-        "id": "pw6esdz94iztk4k23hskj73q",
-        "organization": {
-            "id": "rm4ahxqizjxqbzt3h8itmb3f",
-            "slug": "brian-org",
-            "name": "Brian Org",
-            "description": "",
-            "archived": false,
-            "urls": [],
-            "contacts": []
-        },
-        "country": "BD",
-        "name": "Download Test",
+      "id": "pw6esdz94iztk4k23hskj73q",
+      "organization": {
+        "id": "rm4ahxqizjxqbzt3h8itmb3f",
+        "slug": "brian-org",
+        "name": "Brian Org",
         "description": "",
         "archived": false,
-        "urls": [
-            ""
-        ],
-        "contacts": [],
-        "access": "public",
-        "slug": "download-test",
-        "extent": {
-            "type": "Polygon",
-            "coordinates": [
-                [
-                    [
-                        -0.17329216003417966,
-                        51.51194758264939
-                    ],
-                    [
-                        -0.17303466796874997,
-                        51.511092905004745
-                    ],
-                    [
-                        -0.1709747314453125,
-                        51.51023821132554
-                    ],
-                    [
-                        -0.17329216003417966,
-                        51.51194758264939
-                    ]
-                ]
+        "urls": [],
+        "contacts": []
+      },
+      "country": "BD",
+      "name": "Download Test",
+      "description": "",
+      "archived": false,
+      "urls": [
+        ""
+      ],
+      "contacts": [],
+      "access": "public",
+      "slug": "download-test",
+      "extent": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -0.17329216003417966,
+              51.51194758264939
+            ],
+            [
+              -0.17303466796874997,
+              51.511092905004745
+            ],
+            [
+              -0.1709747314453125,
+              51.51023821132554
+            ],
+            [
+              -0.17329216003417966,
+              51.51194758264939
             ]
-        },
+          ]
+        ]
+      },
     },
     {
-        "id": "jugibdxzaz5i2v3uni5bt6d9",
-        "organization": {
-            "id": "rm4ahxqizjxqbzt3h8itmb3f",
-            "slug": "brian-org",
-            "name": "Brian Org",
-            "description": "",
-            "archived": false,
-            "urls": [],
-            "contacts": []
-        },
-        "country": "BD",
-        "name": "Import Test",
+      "id": "jugibdxzaz5i2v3uni5bt6d9",
+      "organization": {
+        "id": "rm4ahxqizjxqbzt3h8itmb3f",
+        "slug": "brian-org",
+        "name": "Brian Org",
         "description": "",
         "archived": false,
-        "urls": [
-            ""
-        ],
-        "contacts": [],
-        "access": "public",
-        "slug": "import-test-1",
-        "extent": null
+        "urls": [],
+        "contacts": []
+      },
+      "country": "BD",
+      "name": "Import Test",
+      "description": "",
+      "archived": false,
+      "urls": [
+        ""
+      ],
+      "contacts": [],
+      "access": "public",
+      "slug": "import-test-1",
+      "extent": null
     }
-]
-
+  ]
+}
 ```
 
 
@@ -210,97 +215,101 @@ The response body is an array containing multiple [project JSON objects](#projec
 #### Example Response
 
 ```json
-[
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
     {
-        "id": "h8ridjt2jazkac4e97srzmh2",
-        "organization": {
-            "id": "gae6pjf9xygxddgyg5dq45iq",
-            "slug": "example-organization",
-            "name": "Example Organization",
-            "description": "",
-            "archived": false,
-            "urls": [
-                "http://example.com"
-            ],
-            "contacts": null
-        },
-        "country": "",
-        "name": "Atlanta Project",
+      "id": "h8ridjt2jazkac4e97srzmh2",
+      "organization": {
+        "id": "gae6pjf9xygxddgyg5dq45iq",
+        "slug": "example-organization",
+        "name": "Example Organization",
         "description": "",
         "archived": false,
         "urls": [
-            "http://www.atlanta-example.org"
+          "http://example.com"
         ],
-        "contacts": null,
-        "access": "public",
-        "slug": "atlanta-project",
-        "extent": {
-            "type": "Polygon",
-            "coordinates": [
-                [
-                    [
-                        -0.17329216003417966,
-                        51.51194758264939
-                    ],
-                    [
-                        -0.17303466796874997,
-                        51.511092905004745
-                    ],
-                    [
-                        -0.1709747314453125,
-                        51.51023821132554
-                    ],
-                    [
-                        -0.17329216003417966,
-                        51.51194758264939
-                    ]
-                ]
+        "contacts": null
+      },
+      "country": "",
+      "name": "Atlanta Project",
+      "description": "",
+      "archived": false,
+      "urls": [
+        "http://www.atlanta-example.org"
+      ],
+      "contacts": null,
+      "access": "public",
+      "slug": "atlanta-project",
+      "extent": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -0.17329216003417966,
+              51.51194758264939
+            ],
+            [
+              -0.17303466796874997,
+              51.511092905004745
+            ],
+            [
+              -0.1709747314453125,
+              51.51023821132554
+            ],
+            [
+              -0.17329216003417966,
+              51.51194758264939
             ]
-        },
+          ]
+        ]
+      },
     },
     {
-        "id": "hxk4k8aee5rh5htahhh5uenn",
-        "organization": {
-            "id": "gae6pjf9xygxddgyg5dq45iq",
-            "slug": "example-organization",
-            "name": "Example Organization",
-            "description": "",
-            "archived": false,
-            "urls": [
-                "http://example.com"
-            ],
-            "contacts": null
-        },
-        "country": "US",
-        "name": "Portland Project",
+      "id": "hxk4k8aee5rh5htahhh5uenn",
+      "organization": {
+        "id": "gae6pjf9xygxddgyg5dq45iq",
+        "slug": "example-organization",
+        "name": "Example Organization",
         "description": "",
         "archived": false,
         "urls": [
-            ""
+          "http://example.com"
         ],
-        "contacts": [
-            {
-                "name": "Kate",
-                "email": "kate@example.org",
-                "tel": null
-            },
-            {
-                "name": "Oliver",
-                "email": "oliver@example.org",
-                "tel": "444-555-6789"
-            },
-            {
-                "name": "David",
-                "email": null,
-                "tel": "555-555-5555"
-            }
-        ],
-        "access": "public",
-        "slug": "portland-project",
-        "extent": null
+        "contacts": null
+      },
+      "country": "US",
+      "name": "Portland Project",
+      "description": "",
+      "archived": false,
+      "urls": [
+        ""
+      ],
+      "contacts": [
+        {
+          "name": "Kate",
+          "email": "kate@example.org",
+          "tel": null
+        },
+        {
+          "name": "Oliver",
+          "email": "oliver@example.org",
+          "tel": "444-555-6789"
+        },
+        {
+          "name": "David",
+          "email": null,
+          "tel": "555-555-5555"
+        }
+      ],
+      "access": "public",
+      "slug": "portland-project",
+      "extent": null
     }
-]
-
+  ]
+}
 ```
 
 
@@ -320,7 +329,7 @@ GET /api/v1/projects/?permissions={permission[,permission]}
 GET /api/v1/organizations/{organization_slug}/projects/?permissions={permission[,permission]}
 ```
 
-Using the `permissions` query parameter, the list of projects can be filtered according to the permissions the authenticated user has on the individual project. 
+Using the `permissions` query parameter, the list of projects can be filtered according to the permissions the authenticated user has on the individual project.
 
 If you want to list only project where the user can create parties, you request:
 
@@ -375,8 +384,8 @@ URL Parameter | Description
 
 **Request Payload**
 
-Property | Type | Required? | Description 
---- | --- | :---: | --- 
+Property | Type | Required? | Description
+--- | --- | :---: | ---
 `name` | `String` | x | The name of the project.
 `description` | `String` |  | A long-form description of the project.
 `archived` | `Boolean` | | Indicates whether the project has be archived. Defaults to `false`.
@@ -393,51 +402,51 @@ The response body is an array containing a [project JSON object](#project-json-o
 
 ```json
 {
-    "id": "h8ridjt2jazkac4e97srzmh2",
-    "organization": {
-        "id": "gae6pjf9xygxddgyg5dq45iq",
-        "slug": "example-organization",
-        "name": "Example Organization",
-        "description": "",
-        "archived": false,
-        "urls": [
-            "http://example.com"
-        ],
-        "contacts": null
-    },
-    "country": "",
-    "name": "Atlanta Project",
+  "id": "h8ridjt2jazkac4e97srzmh2",
+  "organization": {
+    "id": "gae6pjf9xygxddgyg5dq45iq",
+    "slug": "example-organization",
+    "name": "Example Organization",
     "description": "",
     "archived": false,
     "urls": [
-        "http://www.atlanta-example.org"
+      "http://example.com"
     ],
-    "contacts": null,
-    "access": "public",
-    "slug": "atlanta-project",
-    "extent": {
-        "type": "Polygon",
-        "coordinates": [
-            [
-                [
-                    -0.17329216003417966,
-                    51.51194758264939
-                ],
-                [
-                    -0.17303466796874997,
-                    51.511092905004745
-                ],
-                [
-                    -0.1709747314453125,
-                    51.51023821132554
-                ],
-                [
-                    -0.17329216003417966,
-                    51.51194758264939
-                ]
-            ]
+    "contacts": null
+  },
+  "country": "",
+  "name": "Atlanta Project",
+  "description": "",
+  "archived": false,
+  "urls": [
+    "http://www.atlanta-example.org"
+  ],
+  "contacts": null,
+  "access": "public",
+  "slug": "atlanta-project",
+  "extent": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -0.17329216003417966,
+          51.51194758264939
+        ],
+        [
+          -0.17303466796874997,
+          51.511092905004745
+        ],
+        [
+          -0.1709747314453125,
+          51.51023821132554
+        ],
+        [
+          -0.17329216003417966,
+          51.51194758264939
         ]
-    }
+      ]
+    ]
+  }
 }
 ```
 
@@ -451,7 +460,7 @@ The response body is an array containing a [project JSON object](#project-json-o
 GET /api/v1/organizations/{organization_slug}/projects/{project_slug}/
 ```
 
-Use this method to get at a specific project. 
+Use this method to get at a specific project.
 
 **URL Parameters**
 
@@ -469,68 +478,68 @@ The response body is an array containing a [project JSON object](#project-json-o
 
 ```json
 {
-    "id": "hxk4k8aee5rh5htahhh5uenn",
-    "organization": {
-        "id": "gae6pjf9xygxddgyg5dq45iq",
-        "slug": "example-organization",
-        "name": "Example Organization",
-        "description": "",
-        "archived": false,
-        "urls": [
-            "http://example.com"
-        ],
-        "contacts": null
-    },
-    "country": "US",
-    "name": "Portland Project",
+  "id": "hxk4k8aee5rh5htahhh5uenn",
+  "organization": {
+    "id": "gae6pjf9xygxddgyg5dq45iq",
+    "slug": "example-organization",
+    "name": "Example Organization",
     "description": "",
     "archived": false,
     "urls": [
-        ""
+      "http://example.com"
     ],
-    "contacts": [
-        {
-            "name": "Kate",
-            "email": "kate@example.org",
-            "tel": null
-        },
-        {
-            "name": "Oliver",
-            "email": "oliver@example.org",
-            "tel": "444-555-6789"
-        },
-        {
-            "name": "David",
-            "email": null,
-            "tel": "555-555-5555"
-        }
-    ],
-    "users": [],
-    "access": "public",
-    "slug": "global-project",
-    "extent": {
-        "type": "Polygon",
-        "coordinates": [
-            [
-                [
-                    -0.17329216003417966,
-                    51.51194758264939
-                ],
-                [
-                    -0.17303466796874997,
-                    51.511092905004745
-                ],
-                [
-                    -0.1709747314453125,
-                    51.51023821132554
-                ],
-                [
-                    -0.17329216003417966,
-                    51.51194758264939
-                ]
-            ]
-        ]
+    "contacts": null
+  },
+  "country": "US",
+  "name": "Portland Project",
+  "description": "",
+  "archived": false,
+  "urls": [
+    ""
+  ],
+  "contacts": [
+    {
+      "name": "Kate",
+      "email": "kate@example.org",
+      "tel": null
+    },
+    {
+      "name": "Oliver",
+      "email": "oliver@example.org",
+      "tel": "444-555-6789"
+    },
+    {
+      "name": "David",
+      "email": null,
+      "tel": "555-555-5555"
     }
+  ],
+  "users": [],
+  "access": "public",
+  "slug": "global-project",
+  "extent": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -0.17329216003417966,
+          51.51194758264939
+        ],
+        [
+          -0.17303466796874997,
+          51.511092905004745
+        ],
+        [
+          -0.1709747314453125,
+          51.51023821132554
+        ],
+        [
+          -0.17329216003417966,
+          51.51194758264939
+        ]
+      ]
+    ]
+  }
 }
 ```
 
@@ -542,7 +551,7 @@ The response body is an array containing a [project JSON object](#project-json-o
 PATCH /api/v1/organizations/{organization_slug}/projects/{project_slug}/
 ```
 
-Use this method to update a project in an organization. The fields of the project that you can edit are shown in the request payload below. 
+Use this method to update a project in an organization. The fields of the project that you can edit are shown in the request payload below.
 
 **URL Parameters**
 
@@ -556,8 +565,8 @@ URL Parameter | Description
 
 Using the API, you can update any of the following fields. All of them are optional; fields left blank will remain the same following the update.
 
-Property | Type | Required? | Description 
---- | --- | :---: | --- 
+Property | Type | Required? | Description
+--- | --- | :---: | ---
 `country` | `String` | | The country where the project is located; represented as a two-letter <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2" target="_blank">ISO 3166-1 alpha-2</a> code.
 `name` | `String` | | The name of the project.
 `description`| `String` | | (optional) A long-form description of the project.
@@ -574,83 +583,83 @@ The response body is an array containing a [project JSON object](#project-json-o
 
 ```json
 {
-    "id": "hxk4k8aee5rh5htahhh5uenn",
-    "organization": {
-        "id": "gae6pjf9xygxddgyg5dq45iq",
-        "slug": "example-organization",
-        "name": "Example Organization",
-        "description": "",
-        "archived": false,
-        "urls": [
-            "http://example.com"
-        ],
-        "contacts": null
-    },
-    "country": "US",
-    "name": "Portland Project",
+  "id": "hxk4k8aee5rh5htahhh5uenn",
+  "organization": {
+    "id": "gae6pjf9xygxddgyg5dq45iq",
+    "slug": "example-organization",
+    "name": "Example Organization",
     "description": "",
     "archived": false,
     "urls": [
-        ""
+      "http://example.com"
     ],
-    "contacts": [
-        {
-            "name": "Kate",
-            "email": "kate@example.org",
-            "tel": null
-        },
-        {
-            "name": "Oliver",
-            "email": "oliver@example.org",
-            "tel": "444-555-6789"
-        },
-        {
-            "name": "David",
-            "email": null,
-            "tel": "555-555-5555"
-        }
-    ],
-    "users": [
-        {
-            "username": "dpalomino",
-            "full_name": "David Palomino",
-            "email": "dpalomino@example.org",
-            "email_verified": true,
-            "last_login": "2016-10-24T14:46:56.317086Z"
-        },
-        {
-            "username": "kate",
-            "full_name": "Kate",
-            "email": "kate@example.org",
-            "email_verified": false,
-            "last_login": "2016-10-21T11:00:46.182648Z"
-        }
-    ],
-    "access": "public",
-    "slug": "portland-project",
-    "extent": {
-        "type": "Polygon",
-        "coordinates": [
-            [
-                [
-                    -0.17329216003417966,
-                    51.51194758264939
-                ],
-                [
-                    -0.17303466796874997,
-                    51.511092905004745
-                ],
-                [
-                    -0.1709747314453125,
-                    51.51023821132554
-                ],
-                [
-                    -0.17329216003417966,
-                    51.51194758264939
-                ]
-            ]
-        ]
+    "contacts": null
+  },
+  "country": "US",
+  "name": "Portland Project",
+  "description": "",
+  "archived": false,
+  "urls": [
+    ""
+  ],
+  "contacts": [
+    {
+      "name": "Kate",
+      "email": "kate@example.org",
+      "tel": null
+    },
+    {
+      "name": "Oliver",
+      "email": "oliver@example.org",
+      "tel": "444-555-6789"
+    },
+    {
+      "name": "David",
+      "email": null,
+      "tel": "555-555-5555"
     }
+  ],
+  "users": [
+    {
+      "username": "dpalomino",
+      "full_name": "David Palomino",
+      "email": "dpalomino@example.org",
+      "email_verified": true,
+      "last_login": "2016-10-24T14:46:56.317086Z"
+    },
+    {
+      "username": "kate",
+      "full_name": "Kate",
+      "email": "kate@example.org",
+      "email_verified": false,
+      "last_login": "2016-10-21T11:00:46.182648Z"
+    }
+  ],
+  "access": "public",
+  "slug": "portland-project",
+  "extent": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -0.17329216003417966,
+          51.51194758264939
+        ],
+        [
+          -0.17303466796874997,
+          51.511092905004745
+        ],
+        [
+          -0.1709747314453125,
+          51.51023821132554
+        ],
+        [
+          -0.17329216003417966,
+          51.51194758264939
+        ]
+      ]
+    ]
+  }
 }
 
 ```
@@ -682,7 +691,7 @@ The `role` key resolves to:
 ID | Title
 ---|---
 A  | Organization administrator or platform superuser (has the same permissions as a project manager)
-PM | Project Manager 
+PM | Project Manager
 DC | Data Collector
 PU | Project User
 
@@ -691,12 +700,12 @@ PU | Project User
 
 ```json
 {
-    "username": "kate",
-    "full_name": "Kate",
-    "email": "kate@example.org",
-    "email_verified": false,
-    "last_login": "2016-10-21T11:00:46.182648Z",
-    "role": "PM"
+  "username": "kate",
+  "full_name": "Kate",
+  "email": "kate@example.org",
+  "email_verified": false,
+  "last_login": "2016-10-21T11:00:46.182648Z",
+  "role": "PM"
 }
 ```
 
@@ -722,24 +731,29 @@ The response contains an array of multiple [project member JSON objects](#projec
 #### Example Response
 
 ```json
-[
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
     {
-        "username": "dpalomino",
-        "full_name": "David Palomino",
-        "email": "dpalomino@example.org",
-        "email_verified": true,
-        "last_login": "2016-10-24T14:46:56.317086Z",
-        "role": "DC"
+      "username": "dpalomino",
+      "full_name": "David Palomino",
+      "email": "dpalomino@example.org",
+      "email_verified": true,
+      "last_login": "2016-10-24T14:46:56.317086Z",
+      "role": "DC"
     },
     {
-        "username": "kate",
-        "full_name": "Kate",
-        "email": "kate@example.org",
-        "email_verified": false,
-        "last_login": "2016-10-21T11:00:46.182648Z",
-        "role": "PM"
+      "username": "kate",
+      "full_name": "Kate",
+      "email": "kate@example.org",
+      "email_verified": false,
+      "last_login": "2016-10-21T11:00:46.182648Z",
+      "role": "PM"
     }
-]
+  ]
+}
 ```
 
 
@@ -756,9 +770,9 @@ The response contains an array of multiple [project member JSON objects](#projec
 POST /api/v1/organizations/{organization_slug}/projects/{project_slug}/users/
 ```
 
-Use this method to add a new project member to a project. 
+Use this method to add a new project member to a project.
 
-Note that project members need to already have a user account and be a member of the organization administering the project. 
+Note that project members need to already have a user account and be a member of the organization administering the project.
 
 _Learn more about [creating user accounts](#register-a-new-user--create-a-new-user-account) and [adding organization members](#add-an-organization-member)._
 
@@ -770,8 +784,8 @@ URL Parameter | Description
 
 **Request Payload**
 
-Property | Type | Required? | Description 
---- | --- | :---: | --- 
+Property | Type | Required? | Description
+--- | --- | :---: | ---
 `role` | `String` | x | Indicates the role of the user on the project. (PM = Project Manager, DC = Data Collector, PU = Project User)
 
 **Response**
@@ -783,12 +797,12 @@ The response contains a [project member JSON object](#project-member-json-object
 
 ```json
 {
-    "username": "jane",
-    "full_name": "Jane Doe",
-    "email": "jane@example.org",
-    "email_verified": false,
-    "last_login": "2016-10-27T20:37:19.453868Z",
-    "role": "DC"
+  "username": "jane",
+  "full_name": "Jane Doe",
+  "email": "jane@example.org",
+  "email_verified": false,
+  "last_login": "2016-10-27T20:37:19.453868Z",
+  "role": "DC"
 }
 ```
 
@@ -823,12 +837,12 @@ The response contains a [project member JSON object](#project-member-json-object
 
 ```json
 {
-    "username": "jane",
-    "full_name": "Jane Doe",
-    "email": "jane@example.org",
-    "email_verified": false,
-    "last_login": "2016-10-27T20:37:19.453868Z",
-    "role": "DC"
+  "username": "jane",
+  "full_name": "Jane Doe",
+  "email": "jane@example.org",
+  "email_verified": false,
+  "last_login": "2016-10-27T20:37:19.453868Z",
+  "role": "DC"
 }
 ```
 
@@ -844,7 +858,7 @@ The response contains a [project member JSON object](#project-member-json-object
 PATCH /api/v1/organizations/{organization_slug}/projects/{project_slug}/users/{username}/
 ```
 
-This method allows you to update the permissions granted to a project member. 
+This method allows you to update the permissions granted to a project member.
 
 **URL Parameters**
 
@@ -857,8 +871,8 @@ URL Parameter | Description
 **Request Payload**
 
 
-Property | Type | Required? | Description 
---- | --- | :---: | --- 
+Property | Type | Required? | Description
+--- | --- | :---: | ---
 `role` | `String` | x | Indicates the role of the user on the project. (PM = Project manager, DC = Data Collector, PU = Project User)
 
 You can select one of the following permissions:
@@ -867,7 +881,7 @@ ID | Title
 ---|---
 PU | Project User
 DC | Data Collector
-PM | Project Manager 
+PM | Project Manager
 
 **Response**
 
@@ -877,12 +891,12 @@ The response contains a [project member JSON object](#project-member-json-object
 
 ```json
 {
-    "username": "jane",
-    "full_name": "Jane Doe",
-    "email": "jane@example.org",
-    "email_verified": false,
-    "last_login": "2016-10-27T20:37:19.453868Z",
-    "role": "DC"
+  "username": "jane",
+  "full_name": "Jane Doe",
+  "email": "jane@example.org",
+  "email_verified": false,
+  "last_login": "2016-10-27T20:37:19.453868Z",
+  "role": "DC"
 }
 ```
 
@@ -895,7 +909,7 @@ The response contains a [project member JSON object](#project-member-json-object
 DELETE /api/v1/organizations/{organization_slug}/projects/{project_slug}/users/{username}/
 ```
 
-This method removes a member from a project. 
+This method removes a member from a project.
 
 **URL Parameters**
 

--- a/content/05-questionnaires.md
+++ b/content/05-questionnaires.md
@@ -1,8 +1,8 @@
 ## Questionnaires
 
-Each project in the Cadasta Platform requires a questionnaire in order to work. This questionnaire creates the essential framework for data collection, either online or in the field. 
+Each project in the Cadasta Platform requires a questionnaire in order to work. This questionnaire creates the essential framework for data collection, either online or in the field.
 
-Using the API, you can get the structure of your questionnaire in JSON format, or you can replace the questionnaire being used for a project. 
+Using the API, you can get the structure of your questionnaire in JSON format, or you can replace the questionnaire being used for a project.
 
 Note that you **cannot** replace a questionnaire in an active project once data is being collected about it.
 
@@ -24,7 +24,7 @@ Property | Type | Description
 `id_string` | `String` | The unique ID for the spreadsheet, as defined in the spreadsheet itself in the Settings tab.
 `xls_form` | `String` | Link to an Excel spreadsheet version of the form hosted on Amazon AWS.
 `version` | `String` | Time stamp when the questionnaire was last updated
-`questions` | `Array` | List of questions, charted in the **Questions** section below. 
+`questions` | `Array` | List of questions, charted in the **Questions** section below.
 `question_groups` | `Array` | List of question groups, charted in the **Question Groups** section below.
 
 **Question Groups**
@@ -32,24 +32,24 @@ Property | Type | Description
 Property | Type | Description
 ---|---|---
 `id` | `String` | The ID of the question group.
-`name` | `String` | Question group name, usually used to identify the group in the form. 
+`name` | `String` | Question group name, usually used to identify the group in the form.
 `label` | `String` | Question group label, usually displayed to the user.
-`questions` | `Array` | List of questions in the group. See the Questions table below. 
-`relevant` | `String` | A reference to another field and corresponding value indicating when the field is displayed. 
+`questions` | `Array` | List of questions in the group. See the Questions table below.
+`relevant` | `String` | A reference to another field and corresponding value indicating when the field is displayed.
 
 **Questions**
 
 Property | Type | Description
 ---|---|---
 `id` | `String` | The ID of the question.
-`name` | `String` | Question name, usually used to identify fields in the form. 
+`name` | `String` | Question name, usually used to identify fields in the form.
 `label` | `String` | Question label, usually displayed to the user.
 `type` | `String` | The field type, based on the question types available through <a href="http://xlsform.org/#question-types" target="_blank">XLSforms]</a>. See the table below to see how they translate.
 `required` | `Boolean` | Indicates whether the field is required.
 `constraint` | `String` | The range of accepted values for the field. <a href="http://xlsform.org/#constraints" target="_blank">See XLSForms documentation</a> for more information.
 `default` | `String`  | The default value of the field.
 `hint`| `String` | An additional help text describing details of the field, usually displayed next to the field label.
-`relevant` | `String` | A reference to another field and corresponding value indicating when the field is displayed. 
+`relevant` | `String` | A reference to another field and corresponding value indicating when the field is displayed.
 `options` | `Array` | A list of choices, only relevant if `type` is `select_one` or `select_multiple`. See **Options** table below for more information.
 
 
@@ -58,7 +58,7 @@ Property | Type | Description
 Property | Type | Required? | Description
 ---|---|:---:|---
 `id` | `String` | x | The ID of the choice option.
-`name` | `String`  | x | Choice name, usually as value for the form field. 
+`name` | `String`  | x | Choice name, usually as value for the form field.
 `label` | `String`  | x | Choice label, usually displayed to the user.
 
 **`type` Options**
@@ -103,429 +103,429 @@ The following values are for metadata that your questionnaire may be collecting:
 
 ```json
 {
-    "filename": "wa6hrqr4e4vcf49q6kxjc443",
-    "id": "pignmhca2xgtpprcuw79fawb",
-    "id_string": "wa6hrqr4e4vcf49q6kxjc443",
-    "md5_hash": "0c359dabdbe5006c68c44438ccd86c1f",
-    "question_groups": [
+  "filename": "wa6hrqr4e4vcf49q6kxjc443",
+  "id": "pignmhca2xgtpprcuw79fawb",
+  "id_string": "wa6hrqr4e4vcf49q6kxjc443",
+  "md5_hash": "0c359dabdbe5006c68c44438ccd86c1f",
+  "question_groups": [
+    {
+      "id": "4x5nwwvs523cta83umn6ucc9",
+      "index": 0,
+      "label": "Tenure relationship attributes",
+      "label_xlat": "Tenure relationship attributes",
+      "name": "tenure_relationship_attributes",
+      "question_groups": [],
+      "questions": [
         {
-            "id": "4x5nwwvs523cta83umn6ucc9",
-            "index": 0,
-            "label": "Tenure relationship attributes",
-            "label_xlat": "Tenure relationship attributes",
-            "name": "tenure_relationship_attributes",
-            "question_groups": [],
-            "questions": [
-                {
-                    "constraint": null,
-                    "default": null,
-                    "hint": null,
-                    "id": "2tecu2qsjyihkk7acqwnpdhp",
-                    "index": 0,
-                    "label": "Notes",
-                    "label_xlat": "Notes",
-                    "name": "notes",
-                    "relevant": null,
-                    "required": false,
-                    "type": "TX"
-                }
-            ],
-            "relevant": null,
-            "type": "group"
-        },
-        {
-            "id": "8y8hv2vmp25crcytqf4gcsk3",
-            "index": 1,
-            "label": "Default Party Attributes",
-            "label_xlat": "Default Party Attributes",
-            "name": "party_attributes_default",
-            "question_groups": [],
-            "questions": [
-                {
-                    "constraint": null,
-                    "default": null,
-                    "hint": null,
-                    "id": "dsqj28xdx4m8wu3e8kstnwx7",
-                    "index": 0,
-                    "label": "Notes",
-                    "label_xlat": "Notes",
-                    "name": "notes",
-                    "relevant": null,
-                    "required": false,
-                    "type": "TX"
-                }
-            ],
-            "relevant": null,
-            "type": "group"
-        },
-        {
-            "id": "zu7wigmdketa7xnherh6295f",
-            "index": 2,
-            "label": "Location Attributes",
-            "label_xlat": "Location Attributes",
-            "name": "location_attributes",
-            "question_groups": [],
-            "questions": [
-                {
-                    "constraint": null,
-                    "default": null,
-                    "hint": null,
-                    "id": "wy32hht8ckfrbh4btnk6tg55",
-                    "index": 0,
-                    "label": "Name of Location",
-                    "label_xlat": "Name of Location",
-                    "name": "name",
-                    "relevant": null,
-                    "required": false,
-                    "type": "TX"
-                },
-                {
-                    "constraint": null,
-                    "default": "null",
-                    "hint": "Quality of parcel geometry",
-                    "id": "bcivhzvawbznknrgz99mh55s",
-                    "index": 1,
-                    "label": "Spatial Unit Quality",
-                    "label_xlat": "Spatial Unit Quality",
-                    "name": "quality",
-                    "options": [
-                        {
-                            "id": "gfpftuhcz73wmifur248bh2u",
-                            "index": 1,
-                            "label": "No data",
-                            "label_xlat": "No data",
-                            "name": "null"
-                        },
-                        {
-                            "id": "hid7jsnun2twnnfscvkyx25w",
-                            "index": 2,
-                            "label": "Textual",
-                            "label_xlat": "Textual",
-                            "name": "text"
-                        },
-                        {
-                            "id": "5qssuz7ig5wzymb33d2rat2p",
-                            "index": 3,
-                            "label": "Point data",
-                            "label_xlat": "Point data",
-                            "name": "point"
-                        },
-                        {
-                            "id": "pb8rsyum45hrvwasebmzernb",
-                            "index": 4,
-                            "label": "Low quality polygon",
-                            "label_xlat": "Low quality polygon",
-                            "name": "polygon_low"
-                        },
-                        {
-                            "id": "9pb2uthpy7w44f9yq4vrmgcm",
-                            "index": 5,
-                            "label": "High quality polygon",
-                            "label_xlat": "High quality polygon",
-                            "name": "polygon_high"
-                        }
-                    ],
-                    "relevant": null,
-                    "required": false,
-                    "type": "S1"
-                },
-                {
-                    "constraint": null,
-                    "default": "OT",
-                    "hint": null,
-                    "id": "easzuvr9vyqspai2jg9hcusa",
-                    "index": 2,
-                    "label": "How was this location acquired?",
-                    "label_xlat": "How was this location acquired?",
-                    "name": "acquired_how",
-                    "options": [
-                        {
-                            "id": "3y4j9d35pcy7dnkpmzspd4hz",
-                            "index": 1,
-                            "label": "Contractual Share Crop",
-                            "label_xlat": "Contractual Share Crop",
-                            "name": "CS"
-                        },
-                        {
-                            "id": "hy95hvwvgidx8av7tv5e2va2",
-                            "index": 2,
-                            "label": "Customary Arrangement",
-                            "label_xlat": "Customary Arrangement",
-                            "name": "CA"
-                        },
-                        {
-                            "id": "88i4xdyg9qufm89biarqhcf3",
-                            "index": 3,
-                            "label": "Gift",
-                            "label_xlat": "Gift",
-                            "name": "GF"
-                        }
-                    ],
-                    "relevant": null,
-                    "required": false,
-                    "type": "S1"
-                },
-                {
-                    "constraint": null,
-                    "default": "null",
-                    "hint": null,
-                    "id": "ckargaqthq4gby7f3u5ywd2f",
-                    "index": 3,
-                    "label": "When was this location acquired?",
-                    "label_xlat": "When was this location acquired?",
-                    "name": "acquired_when",
-                    "relevant": null,
-                    "required": false,
-                    "type": "DA"
-                },
-                {
-                    "constraint": null,
-                    "default": null,
-                    "hint": "Additional Notes",
-                    "id": "557mb6s7sv5k8dhcvcqsugc7",
-                    "index": 4,
-                    "label": "Notes",
-                    "label_xlat": "Notes",
-                    "name": "notes",
-                    "relevant": null,
-                    "required": false,
-                    "type": "TX"
-                }
-            ],
-            "relevant": null,
-            "type": "group"
+          "constraint": null,
+          "default": null,
+          "hint": null,
+          "id": "2tecu2qsjyihkk7acqwnpdhp",
+          "index": 0,
+          "label": "Notes",
+          "label_xlat": "Notes",
+          "name": "notes",
+          "relevant": null,
+          "required": false,
+          "type": "TX"
         }
-    ],
-    "questions": [
+      ],
+      "relevant": null,
+      "type": "group"
+    },
+    {
+      "id": "8y8hv2vmp25crcytqf4gcsk3",
+      "index": 1,
+      "label": "Default Party Attributes",
+      "label_xlat": "Default Party Attributes",
+      "name": "party_attributes_default",
+      "question_groups": [],
+      "questions": [
         {
-            "constraint": null,
-            "default": null,
-            "hint": null,
-            "id": "ybqnrd3qbg2a3if75p4ybcda",
-            "index": 3,
-            "label": "Start",
-            "label_xlat": "Start",
-            "name": "start",
-            "relevant": null,
-            "required": false,
-            "type": "ST"
-        },
-        {
-            "constraint": null,
-            "default": null,
-            "hint": null,
-            "id": "d28dw58n6n6ptigkyjcqzqfm",
-            "index": 4,
-            "label": "End",
-            "label_xlat": "End",
-            "name": "end",
-            "relevant": null,
-            "required": false,
-            "type": "EN"
-        },
-        {
-            "constraint": null,
-            "default": null,
-            "hint": null,
-            "id": "vmgdx4mtsuy2tssvc923naat",
-            "index": 5,
-            "label": "Today",
-            "label_xlat": "Today",
-            "name": "today",
-            "relevant": null,
-            "required": false,
-            "type": "TD"
-        },
-        {
-            "constraint": null,
-            "default": null,
-            "hint": null,
-            "id": "ygzf4z769ry28dpfmvnttacm",
-            "index": 6,
-            "label": "DeviceId",
-            "label_xlat": "DeviceId",
-            "name": "deviceid",
-            "relevant": null,
-            "required": false,
-            "type": "DI"
-        },
-        {
-            "constraint": null,
-            "default": null,
-            "hint": null,
-            "id": "w3ihrqpq9pv4g754p68nd4y3",
-            "index": 7,
-            "label": "Cadasta Platform - UAT Survey",
-            "label_xlat": "Cadasta Platform - UAT Survey",
-            "name": "title",
-            "relevant": null,
-            "required": false,
-            "type": "NO"
-        },
-        {
-            "constraint": null,
-            "default": null,
-            "hint": null,
-            "id": "njksjf6sy8imsqhsu5twbdt6",
-            "index": 8,
-            "label": "Party Classification",
-            "label_xlat": "Party Classification",
-            "name": "party_type",
-            "options": [
-                {
-                    "id": "qzaxe9jx5sym69vqxxj2z6s8",
-                    "index": 1,
-                    "label": "Group",
-                    "label_xlat": "Group",
-                    "name": "GR"
-                },
-                {
-                    "id": "4afq8wfhv93czkveb43chqpq",
-                    "index": 2,
-                    "label": "Individual",
-                    "label_xlat": "Individual",
-                    "name": "IN"
-                },
-                {
-                    "id": "9ew3kquph5nw4v4xaccyx7xq",
-                    "index": 3,
-                    "label": "Corporation",
-                    "label_xlat": "Corporation",
-                    "name": "CO"
-                }
-            ],
-            "relevant": null,
-            "required": true,
-            "type": "S1"
-        },
-        {
-            "constraint": null,
-            "default": null,
-            "hint": null,
-            "id": "szdxshbt6hq9f2qpyff4aq6s",
-            "index": 9,
-            "label": "Party Name",
-            "label_xlat": "Party Name",
-            "name": "party_name",
-            "relevant": null,
-            "required": true,
-            "type": "TX"
-        },
-        {
-            "constraint": null,
-            "default": null,
-            "hint": null,
-            "id": "tr42se28bs44m92uc6xtpb9q",
-            "index": 10,
-            "label": "Location of Parcel",
-            "label_xlat": "Location of Parcel",
-            "name": "location_geometry",
-            "relevant": null,
-            "required": false,
-            "type": "GT"
-        },
-        {
-            "constraint": null,
-            "default": null,
-            "hint": null,
-            "id": "sg8x3ggnuwn8ci6frgc9jmw4",
-            "index": 11,
-            "label": "What is the land feature?",
-            "label_xlat": "What is the land feature?",
-            "name": "location_type",
-            "options": [
-                {
-                    "id": "32ks5s69uj7t84ydcniyg5wd",
-                    "index": 1,
-                    "label": "Parcel",
-                    "label_xlat": "Parcel",
-                    "name": "PA"
-                },
-                {
-                    "id": "8z5qq8dtsjtvxgd445ei4rc7",
-                    "index": 2,
-                    "label": "Community Boundary",
-                    "label_xlat": "Community Boundary",
-                    "name": "CB"
-                },
-                {
-                    "id": "ksj3qsxmud8xe67b78pnyri7",
-                    "index": 3,
-                    "label": "Building",
-                    "label_xlat": "Building",
-                    "name": "BU"
-                }
-            ],
-            "relevant": null,
-            "required": true,
-            "type": "S1"
-        },
-        {
-            "constraint": null,
-            "default": null,
-            "hint": null,
-            "id": "umxciy3sz28j379qkxmngjyv",
-            "index": 12,
-            "label": "Photo of Parcel?",
-            "label_xlat": "Photo of Parcel?",
-            "name": "location_photo",
-            "relevant": null,
-            "required": false,
-            "type": "PH"
-        },
-        {
-            "constraint": null,
-            "default": null,
-            "hint": null,
-            "id": "as4tw2yf8bpm7grfxjyxwhf6",
-            "index": 13,
-            "label": "Photo of Party?",
-            "label_xlat": "Photo of Party?",
-            "name": "party_photo",
-            "relevant": null,
-            "required": false,
-            "type": "PH"
-        },
-        {
-            "constraint": null,
-            "default": null,
-            "hint": null,
-            "id": "qwythvtbuech8fgirt3fqapa",
-            "index": 14,
-            "label": "What is the social tenure type?",
-            "label_xlat": "What is the social tenure type?",
-            "name": "tenure_type",
-            "options": [
-                {
-                    "id": "7jxjinrf56vudyfnyuwdytg2",
-                    "index": 1,
-                    "label": "All Types",
-                    "label_xlat": "All Types",
-                    "name": "AL"
-                },
-                {
-                    "id": "7yjd2yqnmdku52em9sst3sck",
-                    "index": 2,
-                    "label": "Carbon Rights",
-                    "label_xlat": "Carbon Rights",
-                    "name": "CR"
-                },
-                {
-                    "id": "37ewegjhj4duvrgqw5erzrnz",
-                    "index": 3,
-                    "label": "Concessionary Rights",
-                    "label_xlat": "Concessionary Rights",
-                    "name": "CO"
-                }
-            ],
-            "relevant": null,
-            "required": true,
-            "type": "S1"
+          "constraint": null,
+          "default": null,
+          "hint": null,
+          "id": "dsqj28xdx4m8wu3e8kstnwx7",
+          "index": 0,
+          "label": "Notes",
+          "label_xlat": "Notes",
+          "name": "notes",
+          "relevant": null,
+          "required": false,
+          "type": "TX"
         }
-    ],
-    "title": "wa6hrqr4e4vcf49q6kxjc443",
-    "version": 2017011815055872,
-    "xls_form": ""
+      ],
+      "relevant": null,
+      "type": "group"
+    },
+    {
+      "id": "zu7wigmdketa7xnherh6295f",
+      "index": 2,
+      "label": "Location Attributes",
+      "label_xlat": "Location Attributes",
+      "name": "location_attributes",
+      "question_groups": [],
+      "questions": [
+        {
+          "constraint": null,
+          "default": null,
+          "hint": null,
+          "id": "wy32hht8ckfrbh4btnk6tg55",
+          "index": 0,
+          "label": "Name of Location",
+          "label_xlat": "Name of Location",
+          "name": "name",
+          "relevant": null,
+          "required": false,
+          "type": "TX"
+        },
+        {
+          "constraint": null,
+          "default": "null",
+          "hint": "Quality of parcel geometry",
+          "id": "bcivhzvawbznknrgz99mh55s",
+          "index": 1,
+          "label": "Spatial Unit Quality",
+          "label_xlat": "Spatial Unit Quality",
+          "name": "quality",
+          "options": [
+            {
+              "id": "gfpftuhcz73wmifur248bh2u",
+              "index": 1,
+              "label": "No data",
+              "label_xlat": "No data",
+              "name": "null"
+            },
+            {
+              "id": "hid7jsnun2twnnfscvkyx25w",
+              "index": 2,
+              "label": "Textual",
+              "label_xlat": "Textual",
+              "name": "text"
+            },
+            {
+              "id": "5qssuz7ig5wzymb33d2rat2p",
+              "index": 3,
+              "label": "Point data",
+              "label_xlat": "Point data",
+              "name": "point"
+            },
+            {
+              "id": "pb8rsyum45hrvwasebmzernb",
+              "index": 4,
+              "label": "Low quality polygon",
+              "label_xlat": "Low quality polygon",
+              "name": "polygon_low"
+            },
+            {
+              "id": "9pb2uthpy7w44f9yq4vrmgcm",
+              "index": 5,
+              "label": "High quality polygon",
+              "label_xlat": "High quality polygon",
+              "name": "polygon_high"
+            }
+          ],
+          "relevant": null,
+          "required": false,
+          "type": "S1"
+        },
+        {
+          "constraint": null,
+          "default": "OT",
+          "hint": null,
+          "id": "easzuvr9vyqspai2jg9hcusa",
+          "index": 2,
+          "label": "How was this location acquired?",
+          "label_xlat": "How was this location acquired?",
+          "name": "acquired_how",
+          "options": [
+            {
+              "id": "3y4j9d35pcy7dnkpmzspd4hz",
+              "index": 1,
+              "label": "Contractual Share Crop",
+              "label_xlat": "Contractual Share Crop",
+              "name": "CS"
+            },
+            {
+              "id": "hy95hvwvgidx8av7tv5e2va2",
+              "index": 2,
+              "label": "Customary Arrangement",
+              "label_xlat": "Customary Arrangement",
+              "name": "CA"
+            },
+            {
+              "id": "88i4xdyg9qufm89biarqhcf3",
+              "index": 3,
+              "label": "Gift",
+              "label_xlat": "Gift",
+              "name": "GF"
+            }
+          ],
+          "relevant": null,
+          "required": false,
+          "type": "S1"
+        },
+        {
+          "constraint": null,
+          "default": "null",
+          "hint": null,
+          "id": "ckargaqthq4gby7f3u5ywd2f",
+          "index": 3,
+          "label": "When was this location acquired?",
+          "label_xlat": "When was this location acquired?",
+          "name": "acquired_when",
+          "relevant": null,
+          "required": false,
+          "type": "DA"
+        },
+        {
+          "constraint": null,
+          "default": null,
+          "hint": "Additional Notes",
+          "id": "557mb6s7sv5k8dhcvcqsugc7",
+          "index": 4,
+          "label": "Notes",
+          "label_xlat": "Notes",
+          "name": "notes",
+          "relevant": null,
+          "required": false,
+          "type": "TX"
+        }
+      ],
+      "relevant": null,
+      "type": "group"
+    }
+  ],
+  "questions": [
+    {
+      "constraint": null,
+      "default": null,
+      "hint": null,
+      "id": "ybqnrd3qbg2a3if75p4ybcda",
+      "index": 3,
+      "label": "Start",
+      "label_xlat": "Start",
+      "name": "start",
+      "relevant": null,
+      "required": false,
+      "type": "ST"
+    },
+    {
+      "constraint": null,
+      "default": null,
+      "hint": null,
+      "id": "d28dw58n6n6ptigkyjcqzqfm",
+      "index": 4,
+      "label": "End",
+      "label_xlat": "End",
+      "name": "end",
+      "relevant": null,
+      "required": false,
+      "type": "EN"
+    },
+    {
+      "constraint": null,
+      "default": null,
+      "hint": null,
+      "id": "vmgdx4mtsuy2tssvc923naat",
+      "index": 5,
+      "label": "Today",
+      "label_xlat": "Today",
+      "name": "today",
+      "relevant": null,
+      "required": false,
+      "type": "TD"
+    },
+    {
+      "constraint": null,
+      "default": null,
+      "hint": null,
+      "id": "ygzf4z769ry28dpfmvnttacm",
+      "index": 6,
+      "label": "DeviceId",
+      "label_xlat": "DeviceId",
+      "name": "deviceid",
+      "relevant": null,
+      "required": false,
+      "type": "DI"
+    },
+    {
+      "constraint": null,
+      "default": null,
+      "hint": null,
+      "id": "w3ihrqpq9pv4g754p68nd4y3",
+      "index": 7,
+      "label": "Cadasta Platform - UAT Survey",
+      "label_xlat": "Cadasta Platform - UAT Survey",
+      "name": "title",
+      "relevant": null,
+      "required": false,
+      "type": "NO"
+    },
+    {
+      "constraint": null,
+      "default": null,
+      "hint": null,
+      "id": "njksjf6sy8imsqhsu5twbdt6",
+      "index": 8,
+      "label": "Party Classification",
+      "label_xlat": "Party Classification",
+      "name": "party_type",
+      "options": [
+        {
+          "id": "qzaxe9jx5sym69vqxxj2z6s8",
+          "index": 1,
+          "label": "Group",
+          "label_xlat": "Group",
+          "name": "GR"
+        },
+        {
+          "id": "4afq8wfhv93czkveb43chqpq",
+          "index": 2,
+          "label": "Individual",
+          "label_xlat": "Individual",
+          "name": "IN"
+        },
+        {
+          "id": "9ew3kquph5nw4v4xaccyx7xq",
+          "index": 3,
+          "label": "Corporation",
+          "label_xlat": "Corporation",
+          "name": "CO"
+        }
+      ],
+      "relevant": null,
+      "required": true,
+      "type": "S1"
+    },
+    {
+      "constraint": null,
+      "default": null,
+      "hint": null,
+      "id": "szdxshbt6hq9f2qpyff4aq6s",
+      "index": 9,
+      "label": "Party Name",
+      "label_xlat": "Party Name",
+      "name": "party_name",
+      "relevant": null,
+      "required": true,
+      "type": "TX"
+    },
+    {
+      "constraint": null,
+      "default": null,
+      "hint": null,
+      "id": "tr42se28bs44m92uc6xtpb9q",
+      "index": 10,
+      "label": "Location of Parcel",
+      "label_xlat": "Location of Parcel",
+      "name": "location_geometry",
+      "relevant": null,
+      "required": false,
+      "type": "GT"
+    },
+    {
+      "constraint": null,
+      "default": null,
+      "hint": null,
+      "id": "sg8x3ggnuwn8ci6frgc9jmw4",
+      "index": 11,
+      "label": "What is the land feature?",
+      "label_xlat": "What is the land feature?",
+      "name": "location_type",
+      "options": [
+        {
+          "id": "32ks5s69uj7t84ydcniyg5wd",
+          "index": 1,
+          "label": "Parcel",
+          "label_xlat": "Parcel",
+          "name": "PA"
+        },
+        {
+          "id": "8z5qq8dtsjtvxgd445ei4rc7",
+          "index": 2,
+          "label": "Community Boundary",
+          "label_xlat": "Community Boundary",
+          "name": "CB"
+        },
+        {
+          "id": "ksj3qsxmud8xe67b78pnyri7",
+          "index": 3,
+          "label": "Building",
+          "label_xlat": "Building",
+          "name": "BU"
+        }
+      ],
+      "relevant": null,
+      "required": true,
+      "type": "S1"
+    },
+    {
+      "constraint": null,
+      "default": null,
+      "hint": null,
+      "id": "umxciy3sz28j379qkxmngjyv",
+      "index": 12,
+      "label": "Photo of Parcel?",
+      "label_xlat": "Photo of Parcel?",
+      "name": "location_photo",
+      "relevant": null,
+      "required": false,
+      "type": "PH"
+    },
+    {
+      "constraint": null,
+      "default": null,
+      "hint": null,
+      "id": "as4tw2yf8bpm7grfxjyxwhf6",
+      "index": 13,
+      "label": "Photo of Party?",
+      "label_xlat": "Photo of Party?",
+      "name": "party_photo",
+      "relevant": null,
+      "required": false,
+      "type": "PH"
+    },
+    {
+      "constraint": null,
+      "default": null,
+      "hint": null,
+      "id": "qwythvtbuech8fgirt3fqapa",
+      "index": 14,
+      "label": "What is the social tenure type?",
+      "label_xlat": "What is the social tenure type?",
+      "name": "tenure_type",
+      "options": [
+        {
+          "id": "7jxjinrf56vudyfnyuwdytg2",
+          "index": 1,
+          "label": "All Types",
+          "label_xlat": "All Types",
+          "name": "AL"
+        },
+        {
+          "id": "7yjd2yqnmdku52em9sst3sck",
+          "index": 2,
+          "label": "Carbon Rights",
+          "label_xlat": "Carbon Rights",
+          "name": "CR"
+        },
+        {
+          "id": "37ewegjhj4duvrgqw5erzrnz",
+          "index": 3,
+          "label": "Concessionary Rights",
+          "label_xlat": "Concessionary Rights",
+          "name": "CO"
+        }
+      ],
+      "relevant": null,
+      "required": true,
+      "type": "S1"
+    }
+  ],
+  "title": "wa6hrqr4e4vcf49q6kxjc443",
+  "version": 2017011815055872,
+  "xls_form": ""
 }
 
 ```
@@ -545,7 +545,7 @@ The following values are for metadata that your questionnaire may be collecting:
 GET /api/v1/organizations/{organization_slug}/projects/{project_slug}/questionnaire/
 ```
 
-Returns the projects current questionnaire structure. 
+Returns the projects current questionnaire structure.
 
 **URL Parameters**
 
@@ -579,9 +579,9 @@ The response body contains a full [questionnaire JSON object](#example-questionn
 PUT /api/v1/organizations/{organization_slug}/projects/{project_slug}/questionnaire/
 ```
 
-This method creates a new questionnaire for the project. Questionnaires are either created by providing a link to a XLSForm or by providing a valid Questionnaire JSON object. 
+This method creates a new questionnaire for the project. Questionnaires are either created by providing a link to a XLSForm or by providing a valid Questionnaire JSON object.
 
-**Note:** At the moment, updating the questionnaire is only possible as long as no data has been contributed to the project. If you need to change your questionnaire, you need to [create a new project](#create-a-new-project). 
+**Note:** At the moment, updating the questionnaire is only possible as long as no data has been contributed to the project. If you need to change your questionnaire, you need to [create a new project](#create-a-new-project).
 
 
 **URL Parameters**
@@ -598,14 +598,14 @@ The request payload is a JSON object containing the following properties.
 
 Property | Description
 ---|---
-`xls_form` | A link to a XLSForm stored on an accessible server. 
+`xls_form` | A link to a XLSForm stored on an accessible server.
 
 
 **Request Payload: Replacement by JSON Object**
 
-> This feature is still being developed. Documentation to be completed when it's done. 
+> This feature is still being developed. Documentation to be completed when it's done.
 
-Creating a questionnaire from a JSON object requires a full [questionnaire JSON object](#example-questionnaire-json-object) provided with the request payload. 
+Creating a questionnaire from a JSON object requires a full [questionnaire JSON object](#example-questionnaire-json-object) provided with the request payload.
 
 **Response**
 

--- a/content/06-records.md
+++ b/content/06-records.md
@@ -1,7 +1,7 @@
 ## Spatial Units (a.k.a Project Locations)
 
 
-Projects in the Cadasta Platform are spatial in nature – collections of points, lines, and polygons representing areas where land rights documentation is happening. These points, lines, and polygons can be retrieved and modified using the Cadasta API.  
+Projects in the Cadasta Platform are spatial in nature – collections of points, lines, and polygons representing areas where land rights documentation is happening. These points, lines, and polygons can be retrieved and modified using the Cadasta API.
 
 _<a href="https://docs.cadasta.org/en/04-records.html#project-locations" target="_blank">Read more about Project Locations in our Platform Documentation</a>_
 
@@ -10,12 +10,12 @@ The endpoint you need to access JSON for spatial units / project locations start
 
 ### Spatial Unit JSON Object
 
-A spatial unit / project location JSON object is a [GEOJSON object](http://geojson.org/) contains the following properties: 
+A spatial unit / project location JSON object is a [GEOJSON object](http://geojson.org/) contains the following properties:
 
 Property | Type | Description
 ---|---|---
 `type` | `String` | This field is automatically set to `Feature`.
-`geometry` | `Object` | A <a href="https://en.wikipedia.org/wiki/GeoJSON#Geometries" target="_blank"> GeoJSON representation</a> of the spatial unit's geometry. 
+`geometry` | `Object` | A <a href="https://en.wikipedia.org/wiki/GeoJSON#Geometries" target="_blank"> GeoJSON representation</a> of the spatial unit's geometry.
 `properties` | `Object` | An object that gives the location a unique ID, defines the type of location it is (land `types`), and lists any attributes. (See  the `properties` table below for more information)
 
 The `properties` object contains the following properties:
@@ -24,7 +24,7 @@ Property | Type | Description
 ---|---|---
 `id` | `String` |  A unique ID for the spatial unit
 `type` | `String` | The type of spatial unit that it is, defined by the fields in your questionnaire. (See the land `types` table below )
-`attributes` | `Object` | Project-specific attributes that are defined through the projects questionnaire. 
+`attributes` | `Object` | Project-specific attributes that are defined through the projects questionnaire.
 
 **Land `type` Abbreviations**
 
@@ -47,45 +47,45 @@ Abbreviation | What it Represents
 ```json
 
 {
-    "type": "Feature",
-    "geometry": {
-        "type": "Polygon",
-        "coordinates": [
-            [
-                [
-                    -122.66475677490233,
-                    45.50045162361647
-                ],
-                [
-                    -122.66956329345703,
-                    45.487395598055215
-                ],
-                [
-                    -122.66252517700195,
-                    45.49954923075264
-                ],
-                [
-                    -122.66475677490233,
-                    45.50045162361647
-                ]
-            ]
+  "type": "Feature",
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -122.66475677490233,
+          45.50045162361647
+        ],
+        [
+          -122.66956329345703,
+          45.487395598055215
+        ],
+        [
+          -122.66252517700195,
+          45.49954923075264
+        ],
+        [
+          -122.66475677490233,
+          45.50045162361647
         ]
-    },
-    "properties": {
-        "id": "39jvd8r93jijahnvgd4s4cih",
-        "type": "PA",
-        "attributes": {},
-        "project": {
-            "id": "hxk4k8aee5rh5htahhh5uenn",
-            "organization": {
-                "id": "gae6pjf9xygxddgyg5dq45iq",
-                "slug": "example-organization",
-                "name": "Example Organization"
-            },
-            "name": "Portland Project",
-            "slug": "portland-project"
-        }
+      ]
+    ]
+  },
+  "properties": {
+    "id": "39jvd8r93jijahnvgd4s4cih",
+    "type": "PA",
+    "attributes": {},
+    "project": {
+      "id": "hxk4k8aee5rh5htahhh5uenn",
+      "organization": {
+        "id": "gae6pjf9xygxddgyg5dq45iq",
+        "slug": "example-organization",
+        "name": "Example Organization"
+      },
+      "name": "Portland Project",
+      "slug": "portland-project"
     }
+  }
 }
 
 ```
@@ -107,7 +107,7 @@ Abbreviation | What it Represents
 GET /api/v1/organizations/{organization_slug}/projects/{project_slug}/spatial/
 ```
 
-Use this method to get a list of all spatial units in a project. 
+Use this method to get a list of all spatial units in a project.
 
 
 **URL Parameters**
@@ -120,7 +120,7 @@ URL Parameter | Description
 **Response**
 
 
-The response body is a GeoJSON feature collection pf multiple [project location / spatial unit JSON objects](#spatial-unit-json-object), but without the `project` property. 
+The response body is a GeoJSON feature collection of multiple [project location / spatial unit JSON objects](#spatial-unit-json-object), but without the `project` property.
 
 
 
@@ -128,63 +128,70 @@ The response body is a GeoJSON feature collection pf multiple [project location 
 
 ```json
 {
-  "type": "FeatureCollection",
-  "features": [{
-    "type": "Feature",
-    "geometry": {
-      "type": "Polygon",
-      "coordinates": [
-        [
-          [
-            -122.7457809448242,
-            45.64344809984393
-          ],[
-            -122.7308464050293,
-            45.640807770704704
-          ],[
-            -122.74543762207031,
-            45.64068775278732
-          ],[
-            -122.7457809448242,
-            45.64344809984393
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -122.7457809448242,
+                45.64344809984393
+              ],[
+                -122.7308464050293,
+                45.640807770704704
+              ],[
+                -122.74543762207031,
+                45.64068775278732
+              ],[
+                -122.7457809448242,
+                45.64344809984393
+              ]
+            ]
           ]
-        ]
-      ]
-    },
-    "properties": {
-      "id": "xtc4de68iawwzgtawp8avgv8",
-      "type": "PA",
-      "attributes": {}
-    }
-  },{
-    "type": "Feature",
-    "geometry": {
-      "type": "Polygon",
-      "coordinates": [
-        [
-          [
-            -122.66475677490233,
-            45.50045162361647
-          ],[
-            -122.66956329345703,
-            45.487395598055215
-          ],[
-            -122.66252517700195,
-            45.49954923075264
-          ],[
-            -122.66475677490233,
-            45.50045162361647
+        },
+        "properties": {
+          "id": "xtc4de68iawwzgtawp8avgv8",
+          "type": "PA",
+          "attributes": {}
+        }
+      },
+      {
+        "type": "Feature",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -122.66475677490233,
+                45.50045162361647
+              ],[
+                -122.66956329345703,
+                45.487395598055215
+              ],[
+                -122.66252517700195,
+                45.49954923075264
+              ],[
+                -122.66475677490233,
+                45.50045162361647
+              ]
+            ]
           ]
-        ]
-      ]
-    },
-      "properties": {
-        "id": "39jvd8r93jijahnvgd4s4cih",
-        "type": "PA",
-        "attributes": {}
+        },
+        "properties": {
+          "id": "39jvd8r93jijahnvgd4s4cih",
+          "type": "PA",
+          "attributes": {}
+        }
       }
-    }
-  ]
+    ]
+  }
 }
 ```
 
@@ -218,11 +225,11 @@ Use this method to create a new spatial unit / project location.
 
 **Request Payload**
 
-Property | Type | Required? | Description 
---- | --- | :---: | --- 
+Property | Type | Required? | Description
+--- | --- | :---: | ---
 `geometry` | `Object` | x | A <a href="https://en.wikipedia.org/wiki/GeoJSON#Geometries" target="_blank"> GeoJSON geometry</a>) defining the geographic coordinates of the location.
 `type` | `String` | x | This refers to the possible land `types` that the location could be (e.g. `PA` = Parcel). See the **Land `type` Abbreviations**  table above for more information.
-`attributes` | `Array` |  | An array of different attributes for the property. 
+`attributes` | `Array` |  | An array of different attributes for the property.
 
 
 **Response**
@@ -233,19 +240,19 @@ The response is a complete [spatial unit / project location JSON Object](#spatia
 
 ```json
 {
-    "type": "Feature",
-    "geometry": {
-        "type": "Point",
-        "coordinates": [
-            -122.7457809448242,
-            45.64344809984393
-        ]
-    },
-    "properties": {
-        "id": "n776cwdhqriaqdwsfafiajib",
-        "type": "MI",
-        "attributes": {}
-    }
+  "type": "Feature",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [
+      -122.7457809448242,
+      45.64344809984393
+    ]
+  },
+  "properties": {
+    "id": "n776cwdhqriaqdwsfafiajib",
+    "type": "MI",
+    "attributes": {}
+  }
 }
 
 ```
@@ -266,7 +273,7 @@ The response is a complete [spatial unit / project location JSON Object](#spatia
 GET /api/v1/organizations/{organization_slug}/projects/{project_slug}/spatial/{spatial_unit_id}/
 ```
 
-Use this method to get the JSON object for a specific spatial unit / project location. 
+Use this method to get the JSON object for a specific spatial unit / project location.
 
 **URL Parameters**
 
@@ -274,7 +281,7 @@ URL Parameter | Description
 ---|---
 `organization_slug` | The slug provided for the organization, which can be found by locating the organization in the [list of all organizations](#list-organizations).
 `project_slug` | The slug provided for the project, which can be found by [listing all of the projects in an organization](#list-all-projects).
-`spatial_unit_id` | The  uniqe ID of the spatial unit, which you can find by [listing all of the spatial units](#list-spatial-units--project-locations) for the project it's in. 
+`spatial_unit_id` | The  uniqe ID of the spatial unit, which you can find by [listing all of the spatial units](#list-spatial-units--project-locations) for the project it's in.
 
 
 **Response**
@@ -286,35 +293,35 @@ The response is a complete [spatial unit / project location JSON Object](#spatia
 
 ```json
 {
-    "type": "Feature",
-    "geometry": {
-        "type": "Polygon",
-        "coordinates": [
-            [
-                [
-                    -122.66475677490233,
-                    45.50045162361647
-                ],
-                [
-                    -122.66956329345703,
-                    45.487395598055215
-                ],
-                [
-                    -122.66252517700195,
-                    45.49954923075264
-                ],
-                [
-                    -122.66475677490233,
-                    45.50045162361647
-                ]
-            ]
+  "type": "Feature",
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -122.66475677490233,
+          45.50045162361647
+        ],
+        [
+          -122.66956329345703,
+          45.487395598055215
+        ],
+        [
+          -122.66252517700195,
+          45.49954923075264
+        ],
+        [
+          -122.66475677490233,
+          45.50045162361647
         ]
-    },
-    "properties": {
-        "id": "39jvd8r93jijahnvgd4s4cih",
-        "type": "PA",
-        "attributes": {}
-    }
+      ]
+    ]
+  },
+  "properties": {
+    "id": "39jvd8r93jijahnvgd4s4cih",
+    "type": "PA",
+    "attributes": {}
+  }
 }
 ```
 
@@ -343,17 +350,17 @@ URL Parameter | Description
 ---|---
 `organization_slug` | The slug provided for the organization, which can be found by locating the organization in the [list of all organizations](#list-organizations).
 `project_slug` | The slug provided for the project, which can be found by [listing all of the projects in an organization](#list-all-projects).
-`spatial_unit_id` | The  unique ID of the spatial unit, which you can find by [listing all of the spatial units](#list-spatial-units--project-locations) for the project it's in.  
+`spatial_unit_id` | The  unique ID of the spatial unit, which you can find by [listing all of the spatial units](#list-spatial-units--project-locations) for the project it's in.
 
 
 
 **Request Payload**
 
-Property | Type | Required? | Description 
---- | --- | :---: | --- 
-`geometry` | `Object` | x | A <a href="https://en.wikipedia.org/wiki/GeoJSON#Geometries" target="_blank"> GeoJSON geometry</a> defining the geographic coordinates of the location. 
+Property | Type | Required? | Description
+--- | --- | :---: | ---
+`geometry` | `Object` | x | A <a href="https://en.wikipedia.org/wiki/GeoJSON#Geometries" target="_blank"> GeoJSON geometry</a> defining the geographic coordinates of the location.
 `type` | `String` | x | This refers to the possible land `types` that the location could be (e.g. `PA` = Parcel). See the land `types` table above for more information.
-`attributes` | `Object` |  | An array of different attributes for the property. 
+`attributes` | `Object` |  | An array of different attributes for the property.
 
 
 **Response**
@@ -365,35 +372,35 @@ The response is a complete [spatial unit / project location JSON Object](#spatia
 
 ```json
 {
-    "type": "Feature",
-    "geometry": {
-        "type": "Polygon",
-        "coordinates": [
-            [
-                [
-                    -122.7457809448242,
-                    45.64344809984393
-                ],
-                [
-                    -122.7457809448235,
-                    45.64344809984442
-                ],
-                [
-                    -122.7457809448219,
-                    45.64344809984999
-                ],
-                [
-                    -122.7457809448242,
-                    45.64344809984393
-                ]
-            ]
+  "type": "Feature",
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -122.7457809448242,
+          45.64344809984393
+        ],
+        [
+          -122.7457809448235,
+          45.64344809984442
+        ],
+        [
+          -122.7457809448219,
+          45.64344809984999
+        ],
+        [
+          -122.7457809448242,
+          45.64344809984393
         ]
-    },
-    "properties": {
-        "id": "w4rwh32mqctn9g223wnry2gx",
-        "type": "PA",
-        "attributes": {}
-    }
+      ]
+    ]
+  },
+  "properties": {
+    "id": "w4rwh32mqctn9g223wnry2gx",
+    "type": "PA",
+    "attributes": {}
+  }
 }
 
 ```
@@ -428,11 +435,11 @@ URL Parameter | Description
 ---|---
 `organization_slug` | The slug provided for the organization, which can be found by locating the organization in the [list of all organizations](#list-organizations).
 `project_slug` | The slug provided for the project, which can be found by [listing all of the projects in an organization](#list-all-projects).
-`spatial_unit_id` | The  unique ID of the spatial unit, which you can find by [listing all of the spatial units](#list-spatial-units--project-locations) for the project it's in. 
+`spatial_unit_id` | The  unique ID of the spatial unit, which you can find by [listing all of the spatial units](#list-spatial-units--project-locations) for the project it's in.
 
 **Response**
 
-If the spatial unit was successfully deleted, an empty response with status code `204` is returned. 
+If the spatial unit was successfully deleted, an empty response with status code `204` is returned.
 
 
 
@@ -442,11 +449,11 @@ If the spatial unit was successfully deleted, an empty response with status code
 
 ## Parties
 
-Each project location has a relationship with people of all kinds – sometimes individuals, sometimes groups, and sometimes a corporation. These people are known as **parties** in the Cadasta system. 
+Each project location has a relationship with people of all kinds – sometimes individuals, sometimes groups, and sometimes a corporation. These people are known as **parties** in the Cadasta system.
 
 _<a href="https://docs.cadasta.org/en/04-records.html#location-relationships" target="_blank">Read more about Parties in our Platform Documentation</a>_
 
-Using the API, you can view, create, update, and delete parties for your project. 
+Using the API, you can view, create, update, and delete parties for your project.
 
 The endpoint for parties begins like this: `/api/v1/organizations/{organization_slug}/projects/{project_slug}/parties/`
 
@@ -454,21 +461,21 @@ The endpoint for parties begins like this: `/api/v1/organizations/{organization_
 
 A party JSON object contains the following properties:
 
-Property | Type | Description 
---- | --- | --- 
+Property | Type | Description
+--- | --- | ---
 `id` | `String` | The auto-generated unique ID for each party.
 `name` | `String` | The name of the party.
 `type` | `String` | The type of party, indicating whether it's an individual (`IN`), a group (`GR`), or a corporation (`CO`).
-`attributes` | `Object` | Project-specific attributes that are defined through the projects questionnaire. 
+`attributes` | `Object` | Project-specific attributes that are defined through the projects questionnaire.
 
 #### Example Party JSON Object
 
 ```json
 {
-    "id": "z8f83bt6fskq6wcvnp223t3q",
-    "name": "Jane Doe",
-    "type": "IN",
-    "attributes": {}
+  "id": "z8f83bt6fskq6wcvnp223t3q",
+  "name": "Jane Doe",
+  "type": "IN",
+  "attributes": {}
 }
 
 
@@ -498,33 +505,37 @@ URL Parameter | Description
 
 **Response**
 
-The response is an array of [party JSON objects](#party-json-object) without the `project` property. 
+The response is an array of [party JSON objects](#party-json-object) without the `project` property.
 
 
 #### Example Response
 
 ```json
-[
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
     {
-        "id": "ajnyj54mpma7kpexxejfv5he",
-        "name": "Example Corp.",
-        "type": "CO",
-        "attributes": {}
+      "id": "ajnyj54mpma7kpexxejfv5he",
+      "name": "Example Corp.",
+      "type": "CO",
+      "attributes": {}
     },
     {
-        "id": "cnpsvntqugkncywqevhznnsz",
-        "name": "Elizabeth James",
-        "type": "IN",
-        "attributes": {}
+      "id": "cnpsvntqugkncywqevhznnsz",
+      "name": "Elizabeth James",
+      "type": "IN",
+      "attributes": {}
     },
     {
-        "id": "wvvi6sbgdf77nfwbe26fgz3z",
-        "name": "Portland Islands Neighborhood Association",
-        "type": "GR",
-        "attributes": {}
+      "id": "wvvi6sbgdf77nfwbe26fgz3z",
+      "name": "Portland Islands Neighborhood Association",
+      "type": "GR",
+      "attributes": {}
     }
-]
-
+  ]
+}
 ```
 
 
@@ -555,24 +566,24 @@ URL Parameter | Description
 
 **Request Payload**
 
-Property | Type | Required? | Description 
---- | --- | :---: | --- 
+Property | Type | Required? | Description
+--- | --- | :---: | ---
 `name` | CharField | x | The name of the party.
 `type` | ChoiceField | x | The type of party, indicating whether it's an individual (`IN`), a group (`GR`), or a corporation (`CO`).
-`attributes` | Object |  | Project-specific attributes that are defined through the projects questionnaire. 
+`attributes` | Object |  | Project-specific attributes that are defined through the projects questionnaire.
 
 **Response**
 
-The response is a [party JSON object](#party-json-object). 
+The response is a [party JSON object](#party-json-object).
 
 #### Example Response
 
 ```json
 {
-    "id": "z8f83bt6fskq6wcvnp223t3q",
-    "name": "Jane Doe",
-    "type": "IN",
-    "attributes": {}
+  "id": "z8f83bt6fskq6wcvnp223t3q",
+  "name": "Jane Doe",
+  "type": "IN",
+  "attributes": {}
 }
 
 ```
@@ -594,28 +605,28 @@ The response is a [party JSON object](#party-json-object).
 GET /api/v1/organizations/{organization_slug}/projects/{project_slug}/parties/{party_id}/
 ```
 
-Use this method to get at a specific party. 
+Use this method to get at a specific party.
 
 
 URL Parameter | Description
 ---|---
 `organization_slug` | The slug provided for the organization, which can be found by locating the organization in the [list of all organizations](#list-organizations).
 `project_slug` | The slug provided for the project, which can be found by [listing all of the projects in an organization](#list-all-projects).
-`party_id` | The unique ID generated for the specific party, which can be found by [listing all of the parties](#list-parties). 
+`party_id` | The unique ID generated for the specific party, which can be found by [listing all of the parties](#list-parties).
 
 
 **Response**
 
-The response contains a [party JSON object](#party-json-object). 
+The response contains a [party JSON object](#party-json-object).
 
 #### Example Response
 
 ```json
 {
-    "id": "z8f83bt6fskq6wcvnp223t3q",
-    "name": "Jane Doe",
-    "type": "IN",
-    "attributes": {}
+  "id": "z8f83bt6fskq6wcvnp223t3q",
+  "name": "Jane Doe",
+  "type": "IN",
+  "attributes": {}
 }
 ```
 
@@ -648,33 +659,33 @@ URL Parameter | Description
 ---|---
 `organization_slug` | The slug provided for the organization, which can be found by locating the organization in the [list of all organizations](#list-organizations).
 `project_slug` | The slug provided for the project, which can be found by [listing all of the projects in an organization](#list-all-projects).
-`party_id` | The unique ID generated for the specific party, which can be found by [listing all of the parties](#list-parties). 
+`party_id` | The unique ID generated for the specific party, which can be found by [listing all of the parties](#list-parties).
 
 
 **Request Payload**
 
 You can modify any one of these fields:
 
-Property | Type  | Required? | Description 
+Property | Type  | Required? | Description
 --- | --- | --- | ---
 `name` | `String` |  | The name of the party.
 `type` | `String` |  | The type of party, indicating whether it's an individual (`IN`), a group (`GR`), or a corporation (`CO`).
-`attributes` | `Object` |  | Project-specific attributes that are defined through the projects questionnaire. 
+`attributes` | `Object` |  | Project-specific attributes that are defined through the projects questionnaire.
 
 
 **Response**
 
-The response contains a [party JSON object](#party-json-object). 
+The response contains a [party JSON object](#party-json-object).
 
 
 #### Example Response
 
 ```json
 {
-    "id": "z8f83bt6fskq6wcvnp223t3q",
-    "name": "Jane Doe",
-    "type": "IN",
-    "attributes": {}
+  "id": "z8f83bt6fskq6wcvnp223t3q",
+  "name": "Jane Doe",
+  "type": "IN",
+  "attributes": {}
 }
 
 ```
@@ -701,13 +712,13 @@ The response contains a [party JSON object](#party-json-object).
 DELETE /api/v1/organizations/{organization_slug}/projects/{project_slug}/parties/{party_id}/
 ```
 
-Use this method and endpoint to delete a party. 
+Use this method and endpoint to delete a party.
 
 URL Parameter | Description
 ---|---
 `organization_slug` | The slug provided for the organization, which can be found by locating the organization in the [list of all organizations](#list-organizations).
 `project_slug` | The slug provided for the project, which can be found by [listing all of the projects in an organization](#list-all-projects).
-`party_id` | The unique ID generated for the specific party, which can be found by [listing all of the parties](#list-parties). 
+`party_id` | The unique ID generated for the specific party, which can be found by [listing all of the parties](#list-parties).
 
 **Response**
 
@@ -754,27 +765,27 @@ or
 A relationship object contains the following properties:
 
 
-Property | Type | Description 
---- | --- | --- 
+Property | Type | Description
+--- | --- | ---
 `rel_class`| `String` | The type of relationships; currently `"tenure"` is the only possible relationship type.
 `id` | `String`  | The unique ID of the relationship
 `party` | `Array` | The object containing the party that the spatial unit is related to. (See the `party` table below for more information.)
 `spatial_unit` | `Object` | The spatial unit / project location object. (See the `spatial unit` table below for more information.)
 `tenure_type`| `String` |  The kind of relationship. (See the Relationship (Tenure) Categories table for more information.)
-`attributes`| `Object`  | Project-specific attributes that are defined through the project's questionnaire. 
+`attributes`| `Object`  | Project-specific attributes that are defined through the project's questionnaire.
 
-The `party` object has the following properties: 
+The `party` object has the following properties:
 
-Property | Type | Description 
---- | --- | --- 
-`id` | `String` | The unique ID of the party. 
+Property | Type | Description
+--- | --- | ---
+`id` | `String` | The unique ID of the party.
 `name` | `String` | The name of the party.
 `type` | `String` |  The type of party, e.g. an individual (`IN`), a group (`GR`), or a corporation (`CO`).
 
 The `spatial_unit` object has the following properties:
 
-Property | Type | Description 
---- | --- | --- 
+Property | Type | Description
+--- | --- | ---
 `type` | `String` | Type of spatial unit; automatically set to `Feature`.
 `geometry` | `Object` |  A <a href="https://en.wikipedia.org/wiki/GeoJSON#Geometries" target="_blank"> GeoJSON representation</a> of the spatial unit's geometry.
 `properties` | `Object` | An object that gives the location a unique ID and defines the type of location it is (land `types`). (See  the `properties` table below for more information)
@@ -783,45 +794,52 @@ Property | Type | Description
 
 ```json
 {
-    "rel_class": "tenure",
-    "id": "mmikx24rcjd2stgyqz495fqa",
-    "party": {
+  "count": 1,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "rel_class": "tenure",
+      "id": "mmikx24rcjd2stgyqz495fqa",
+      "party": {
         "id": "wvvi6sbgdf77nfwbe26fgz3z",
         "name": "Portland Islands Neighborhood Association",
         "type": "GR"
-    },
-    "spatial_unit": {
+      },
+      "spatial_unit": {
         "type": "Feature",
         "geometry": {
-            "type": "Polygon",
-            "coordinates": [
-                [
-                    [
-                        -122.7457809448242,
-                        45.64344809984393
-                    ],
-                    [
-                        -122.7308464050293,
-                        45.640807770704704
-                    ],
-                    [
-                        -122.74543762207031,
-                        45.64068775278732
-                    ],
-                    [
-                        -122.7457809448242,
-                        45.64344809984393
-                    ]
-                ]
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -122.7457809448242,
+                45.64344809984393
+              ],
+              [
+                -122.7308464050293,
+                45.640807770704704
+              ],
+              [
+                -122.74543762207031,
+                45.64068775278732
+              ],
+              [
+                -122.7457809448242,
+                45.64344809984393
+              ]
             ]
+          ]
         },
         "properties": {
-            "id": "xtc4de68iawwzgtawp8avgv8",
-            "type": "PA"
+          "id": "xtc4de68iawwzgtawp8avgv8",
+          "type": "PA"
         }
-    },
-    "tenure_type": "TN",
-    "attributes": {}
+      },
+      "tenure_type": "TN",
+      "attributes": {}
+    }
+  ]
 }
 ```
 
@@ -894,142 +912,147 @@ URL Parameter | Description
 ---|---
 `organization_slug` | The slug provided for the organization, which can be found by locating the organization in the [list of all organizations](#list-organizations).
 `project_slug` | The slug provided for the project, which can be found by [listing all of the projects in an organization](#list-all-projects).
-`party_id` | **Only required when listing relationships to a party.** The unique ID generated for the specific party, which can be found by [listing all of the parties](#list-parties). 
-`spatial_unit_id` | **Only required when listing relationships to a spatial unit.** The unique ID generated for the specific spatial unit, which can be found by [listing all of the spatial units](#list-spatial-units--project-locations). 
+`party_id` | **Only required when listing relationships to a party.** The unique ID generated for the specific party, which can be found by [listing all of the parties](#list-parties).
+`spatial_unit_id` | **Only required when listing relationships to a spatial unit.** The unique ID generated for the specific spatial unit, which can be found by [listing all of the spatial units](#list-spatial-units--project-locations).
 
 **Response**
 
-The response contains a list of [relationship JSON objects](#relationship-json-object). 
+The response contains a list of [relationship JSON objects](#relationship-json-object).
 
 
 #### Example Response
 
 ```json
-[
+{
+  "count": 3,
+  "next": null,
+  "previous": null,
+  "results": [
     {
-        "rel_class": "tenure",
-        "id": "mmikx24rcjd2stgyqz495fqa",
-        "party": {
-            "id": "wvvi6sbgdf77nfwbe26fgz3z",
-            "name": "Portland Islands Neighborhood Association",
-            "type": "GR"
+      "rel_class": "tenure",
+      "id": "mmikx24rcjd2stgyqz495fqa",
+      "party": {
+        "id": "wvvi6sbgdf77nfwbe26fgz3z",
+        "name": "Portland Islands Neighborhood Association",
+        "type": "GR"
+      },
+      "spatial_unit": {
+        "type": "Feature",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -122.7457809448242,
+                45.64344809984393
+              ],
+              [
+                -122.7308464050293,
+                45.640807770704704
+              ],
+              [
+                -122.74543762207031,
+                45.64068775278732
+              ],
+              [
+                -122.7457809448242,
+                45.64344809984393
+              ]
+            ]
+          ]
         },
-        "spatial_unit": {
-            "type": "Feature",
-            "geometry": {
-                "type": "Polygon",
-                "coordinates": [
-                    [
-                        [
-                            -122.7457809448242,
-                            45.64344809984393
-                        ],
-                        [
-                            -122.7308464050293,
-                            45.640807770704704
-                        ],
-                        [
-                            -122.74543762207031,
-                            45.64068775278732
-                        ],
-                        [
-                            -122.7457809448242,
-                            45.64344809984393
-                        ]
-                    ]
-                ]
-            },
-            "properties": {
-                "id": "xtc4de68iawwzgtawp8avgv8",
-                "type": "PA"
-            }
-        },
-        "tenure_type": "TN",
-        "attributes": {}
+        "properties": {
+          "id": "xtc4de68iawwzgtawp8avgv8",
+          "type": "PA"
+        }
+      },
+      "tenure_type": "TN",
+      "attributes": {}
     },
     {
-        "rel_class": "tenure",
-        "id": "f2eq96ez7rnkucwz9sr4my9y",
-        "party": {
-            "id": "ajnyj54mpma7kpexxejfv5he",
-            "name": "Example Corp.",
-            "type": "CO"
+      "rel_class": "tenure",
+      "id": "f2eq96ez7rnkucwz9sr4my9y",
+      "party": {
+        "id": "ajnyj54mpma7kpexxejfv5he",
+        "name": "Example Corp.",
+        "type": "CO"
+      },
+      "spatial_unit": {
+        "type": "Feature",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -122.7457809448242,
+                45.64344809984393
+              ],
+              [
+                -122.7308464050293,
+                45.640807770704704
+              ],
+              [
+                -122.74543762207031,
+                45.64068775278732
+              ],
+              [
+                -122.7457809448242,
+                45.64344809984393
+              ]
+            ]
+          ]
         },
-        "spatial_unit": {
-            "type": "Feature",
-            "geometry": {
-                "type": "Polygon",
-                "coordinates": [
-                    [
-                        [
-                            -122.7457809448242,
-                            45.64344809984393
-                        ],
-                        [
-                            -122.7308464050293,
-                            45.640807770704704
-                        ],
-                        [
-                            -122.74543762207031,
-                            45.64068775278732
-                        ],
-                        [
-                            -122.7457809448242,
-                            45.64344809984393
-                        ]
-                    ]
-                ]
-            },
-            "properties": {
-                "id": "xtc4de68iawwzgtawp8avgv8",
-                "type": "PA"
-            }
-        },
-        "tenure_type": "LL",
-        "attributes": {}
+        "properties": {
+          "id": "xtc4de68iawwzgtawp8avgv8",
+          "type": "PA"
+        }
+      },
+      "tenure_type": "LL",
+      "attributes": {}
     },
     {
-        "rel_class": "tenure",
-        "id": "5ueeskcsfgf4iuwcgmji3dik",
-        "party": {
-            "id": "cnpsvntqugkncywqevhznnsz",
-            "name": "Joan Arches",
-            "type": "IN"
+      "rel_class": "tenure",
+      "id": "5ueeskcsfgf4iuwcgmji3dik",
+      "party": {
+        "id": "cnpsvntqugkncywqevhznnsz",
+        "name": "Joan Arches",
+        "type": "IN"
+      },
+      "spatial_unit": {
+        "type": "Feature",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -122.7457809448242,
+                45.64344809984393
+              ],
+              [
+                -122.7308464050293,
+                45.640807770704704
+              ],
+              [
+                -122.74543762207031,
+                45.64068775278732
+              ],
+              [
+                -122.7457809448242,
+                45.64344809984393
+              ]
+            ]
+          ]
         },
-        "spatial_unit": {
-            "type": "Feature",
-            "geometry": {
-                "type": "Polygon",
-                "coordinates": [
-                    [
-                        [
-                            -122.7457809448242,
-                            45.64344809984393
-                        ],
-                        [
-                            -122.7308464050293,
-                            45.640807770704704
-                        ],
-                        [
-                            -122.74543762207031,
-                            45.64068775278732
-                        ],
-                        [
-                            -122.7457809448242,
-                            45.64344809984393
-                        ]
-                    ]
-                ]
-            },
-            "properties": {
-                "id": "xtc4de68iawwzgtawp8avgv8",
-                "type": "PA"
-            }
-        },
-        "tenure_type": "WR",
-        "attributes": {}
+        "properties": {
+          "id": "xtc4de68iawwzgtawp8avgv8",
+          "type": "PA"
+        }
+      },
+      "tenure_type": "WR",
+      "attributes": {}
     }
-]
+  ]
+}
 ```
 
 
@@ -1049,7 +1072,7 @@ The response contains a list of [relationship JSON objects](#relationship-json-o
 
 ### Create a New  Relationship
 
-This section is still in progress. 
+This section is still in progress.
 
 
 ```endpoint
@@ -1058,12 +1081,12 @@ POST /api/v1/organizations/{organization_slug}/projects/{project_slug}/relations
 
 **Request Payload**
 
-Property | Type | Required? | Description 
---- | --- | :---: | --- 
+Property | Type | Required? | Description
+--- | --- | :---: | ---
 `party` | `String` | x | The ID of the party connected to the new relationship.
 `spatial_unit` | `String` | x | The ID of the spatial connected to the new relationship.
 `tenure_type` | `String` | x | The tenure relationship category.
-`attributes` | `Object` | x | Project-specific attributes that are defined through the project's questionnaire. 
+`attributes` | `Object` | x | Project-specific attributes that are defined through the project's questionnaire.
 
 
 **Response**
@@ -1074,45 +1097,45 @@ The response contains a [relationship JSON object](#relationship-json-object).
 
 ```json
 {
-    "rel_class": "tenure",
-    "id": "f2eq96ez7rnkucwz9sr4my9y",
-    "party": {
-        "id": "ajnyj54mpma7kpexxejfv5he",
-        "name": "Example Corp.",
-        "type": "CO"
+  "rel_class": "tenure",
+  "id": "f2eq96ez7rnkucwz9sr4my9y",
+  "party": {
+    "id": "ajnyj54mpma7kpexxejfv5he",
+    "name": "Example Corp.",
+    "type": "CO"
+  },
+  "spatial_unit": {
+    "type": "Feature",
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -122.7457809448242,
+            45.64344809984393
+          ],
+          [
+            -122.7308464050293,
+            45.640807770704704
+          ],
+          [
+            -122.74543762207031,
+            45.64068775278732
+          ],
+          [
+            -122.7457809448242,
+            45.64344809984393
+          ]
+        ]
+      ]
     },
-    "spatial_unit": {
-        "type": "Feature",
-        "geometry": {
-            "type": "Polygon",
-            "coordinates": [
-                [
-                    [
-                        -122.7457809448242,
-                        45.64344809984393
-                    ],
-                    [
-                        -122.7308464050293,
-                        45.640807770704704
-                    ],
-                    [
-                        -122.74543762207031,
-                        45.64068775278732
-                    ],
-                    [
-                        -122.7457809448242,
-                        45.64344809984393
-                    ]
-                ]
-            ]
-        },
-        "properties": {
-            "id": "xtc4de68iawwzgtawp8avgv8",
-            "type": "PA"
-        }
-    },
-    "tenure_type": "LL",
-    "attributes": {}
+    "properties": {
+      "id": "xtc4de68iawwzgtawp8avgv8",
+      "type": "PA"
+    }
+  },
+  "tenure_type": "LL",
+  "attributes": {}
 }
 ```
 
@@ -1137,13 +1160,13 @@ The response contains a [relationship JSON object](#relationship-json-object).
 GET /api/v1/organizations/{organization_slug}/projects/{project_slug}/relationships/tenure/{relationship_id}/
 ```
 
-Use this method and endpoint to get a specific  relationship. 
+Use this method and endpoint to get a specific  relationship.
 
 URL Parameter | Description
 ---|---
 `organization_slug` | The slug provided for the organization, which can be found by locating the organization in the [list of all organizations](#list-organizations).
 `project_slug` | The slug provided for the project, which can be found by [listing all of the projects in an organization](#list-all-projects).
-`relationship_id` | The unique ID of the relationship, which can be found by [listing all of the relationships to a spatial unit](#list-relationships). 
+`relationship_id` | The unique ID of the relationship, which can be found by [listing all of the relationships to a spatial unit](#list-relationships).
 
 **Response**
 
@@ -1154,45 +1177,45 @@ The response contains a relationship JSON object.
 
 ```json
 {
-    "rel_class": "tenure",
-    "id": "f2eq96ez7rnkucwz9sr4my9y",
-    "party": {
-        "id": "ajnyj54mpma7kpexxejfv5he",
-        "name": "Example Corp.",
-        "type": "CO"
+  "rel_class": "tenure",
+  "id": "f2eq96ez7rnkucwz9sr4my9y",
+  "party": {
+    "id": "ajnyj54mpma7kpexxejfv5he",
+    "name": "Example Corp.",
+    "type": "CO"
+  },
+  "spatial_unit": {
+    "type": "Feature",
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -122.7457809448242,
+            45.64344809984393
+          ],
+          [
+            -122.7308464050293,
+            45.640807770704704
+          ],
+          [
+            -122.74543762207031,
+            45.64068775278732
+          ],
+          [
+            -122.7457809448242,
+            45.64344809984393
+          ]
+        ]
+      ]
     },
-    "spatial_unit": {
-        "type": "Feature",
-        "geometry": {
-            "type": "Polygon",
-            "coordinates": [
-                [
-                    [
-                        -122.7457809448242,
-                        45.64344809984393
-                    ],
-                    [
-                        -122.7308464050293,
-                        45.640807770704704
-                    ],
-                    [
-                        -122.74543762207031,
-                        45.64068775278732
-                    ],
-                    [
-                        -122.7457809448242,
-                        45.64344809984393
-                    ]
-                ]
-            ]
-        },
-        "properties": {
-            "id": "xtc4de68iawwzgtawp8avgv8",
-            "type": "PA"
-        }
-    },
-    "tenure_type": "LL",
-    "attributes": {}
+    "properties": {
+      "id": "xtc4de68iawwzgtawp8avgv8",
+      "type": "PA"
+    }
+  },
+  "tenure_type": "LL",
+  "attributes": {}
 }
 ```
 
@@ -1241,15 +1264,15 @@ URL Parameter | Description
 ---|---
 `organization_slug` | The slug provided for the organization, which can be found by locating the organization in the [list of all organizations](#list-organizations).
 `project_slug` | The slug provided for the project, which can be found by [listing all of the projects in an organization](#list-all-projects).
-`relationship_id` | The unique ID of the relationship, which can be found by [listing all of the relationships to a spatial unit](#list-relationships). 
+`relationship_id` | The unique ID of the relationship, which can be found by [listing all of the relationships to a spatial unit](#list-relationships).
 
 
 **Request Payload**
 
-Property | Type | Required? | Description 
---- | --- | :---: | --- 
+Property | Type | Required? | Description
+--- | --- | :---: | ---
 `tenure_type` | `String` | | The relationship type; see Relationship (Tenure) Categories for an overview of accepted values.
-`attributes` | `Object` | | Project-specific attributes that are defined through the projects questionnaire. 
+`attributes` | `Object` | | Project-specific attributes that are defined through the projects questionnaire.
 
 **Response**
 
@@ -1259,45 +1282,45 @@ The response contains a [relationship JSON object](#relationship-json-object).
 
 ```json
 {
-    "rel_class": "tenure",
-    "id": "f2eq96ez7rnkucwz9sr4my9y",
-    "party": {
-        "id": "ajnyj54mpma7kpexxejfv5he",
-        "name": "Example Corp.",
-        "type": "CO"
+  "rel_class": "tenure",
+  "id": "f2eq96ez7rnkucwz9sr4my9y",
+  "party": {
+    "id": "ajnyj54mpma7kpexxejfv5he",
+    "name": "Example Corp.",
+    "type": "CO"
+  },
+  "spatial_unit": {
+    "type": "Feature",
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            -122.7457809448242,
+            45.64344809984393
+          ],
+          [
+            -122.7308464050293,
+            45.640807770704704
+          ],
+          [
+            -122.74543762207031,
+            45.64068775278732
+          ],
+          [
+            -122.7457809448242,
+            45.64344809984393
+          ]
+        ]
+      ]
     },
-    "spatial_unit": {
-        "type": "Feature",
-        "geometry": {
-            "type": "Polygon",
-            "coordinates": [
-                [
-                    [
-                        -122.7457809448242,
-                        45.64344809984393
-                    ],
-                    [
-                        -122.7308464050293,
-                        45.640807770704704
-                    ],
-                    [
-                        -122.74543762207031,
-                        45.64068775278732
-                    ],
-                    [
-                        -122.7457809448242,
-                        45.64344809984393
-                    ]
-                ]
-            ]
-        },
-        "properties": {
-            "id": "xtc4de68iawwzgtawp8avgv8",
-            "type": "PA"
-        }
-    },
-    "tenure_type": "LL",
-    "attributes": {}
+    "properties": {
+      "id": "xtc4de68iawwzgtawp8avgv8",
+      "type": "PA"
+    }
+  },
+  "tenure_type": "LL",
+  "attributes": {}
 }
 ```
 
@@ -1330,7 +1353,7 @@ URL Parameter | Description
 ---|---
 `organization_slug` | The slug provided for the organization, which can be found by locating the organization in the [list of all organizations](#list-organizations).
 `project_slug` | The slug provided for the project, which can be found by [listing all of the projects in an organization](#list-all-projects).
-`relationship_id` | The unique ID of the relationship, which can be found by [listing all of the relationships to a spatial unit](#list-relationships). 
+`relationship_id` | The unique ID of the relationship, which can be found by [listing all of the relationships to a spatial unit](#list-relationships).
 
 
 **Response**

--- a/content/07-resources.md
+++ b/content/07-resources.md
@@ -14,8 +14,8 @@ To access project resources using the API, use the following endpoint:
 
 Each project resource appears as a JSON object with the following properties:
 
-Property | Type | Description 
---- | --- | --- 
+Property | Type | Description
+--- | --- | ---
 `id` | `String` | A unique ID automatically generated for the file.
 `name` | `String` | The name of the file (e.g. Deed of Trust)
 `description` | `String` | A description of the file (e.g. The only deed we can find that has information relevant to the site.)
@@ -28,12 +28,12 @@ Property | Type | Description
 
 ```json
 {
-	"id": "8u5dgnvgzix6kmg9hvbfdy3c",
-	"name": "Deed",
-	"description": "",
-	"file": "https://example.com/resources/wcajeysz7ngrae3bd84af99q.pdf",
-	"original_file": "Deed-of-Trust-1912.pdf",
-	"archived": false
+  "id": "8u5dgnvgzix6kmg9hvbfdy3c",
+  "name": "Deed",
+  "description": "",
+  "file": "https://example.com/resources/wcajeysz7ngrae3bd84af99q.pdf",
+  "original_file": "Deed-of-Trust-1912.pdf",
+  "archived": false
 }
 ```
 
@@ -57,7 +57,7 @@ Property | Type | Description
 GET /api/v1/organizations/{organization_slug}/projects/{project_slug}/resources/
 ```
 
-Use this method and endpoint to list out all the resources associated with any given project. 
+Use this method and endpoint to list out all the resources associated with any given project.
 
 **URL Parameters**
 
@@ -74,33 +74,37 @@ The response body is an array containing a series of [project resource JSON obje
 #### Example Response
 
 ```json
-[
+{
+  "count": 3,
+  "next": null,
+  "previous": null,
+  "results": [
     {
-        "id": "8u5dgnvgzix6kmg9hvbfdy3c",
-        "name": "Deed",
-        "description": "",
-        "file": "https://example.com/resources/wcajeysz7ngrae3bd84af99q.pdf",
-        "original_file": "Deed-of-Trust-1912.pdf",
-        "archived": false
+      "id": "8u5dgnvgzix6kmg9hvbfdy3c",
+      "name": "Deed",
+      "description": "",
+      "file": "https://example.com/resources/wcajeysz7ngrae3bd84af99q.pdf",
+      "original_file": "Deed-of-Trust-1912.pdf",
+      "archived": false
     },
     {
-        "id": "xnbqgubg99x6w54q363tjx5d",
-        "name": "Ross Island - 1963",
-        "description": "",
-        "file": "https://example.com/resources/tab6kkdfx9c5pifzsmmh4iep.jpg",
-        "original_file": "a2004-001-1012-marquam-bridge-under-construction-1963.jpg",
-        "archived": false
+      "id": "xnbqgubg99x6w54q363tjx5d",
+      "name": "Ross Island - 1963",
+      "description": "",
+      "file": "https://example.com/resources/tab6kkdfx9c5pifzsmmh4iep.jpg",
+      "original_file": "a2004-001-1012-marquam-bridge-under-construction-1963.jpg",
+      "archived": false
     },
     {
-        "id": "p5d2wb5xnj4bn93vve8ntzwc",
-        "name": "Ross Island Aerial - 1945",
-        "description": "",
-        "file": "https://example.com/resources/acguba29wstyexf8uhxkvezn.jpg",
-        "original_file": "a2005-001-815-ross-island-bridge-west-approach-north-at-sw-kelly-1945.jpg",
-        "archived": false
+      "id": "p5d2wb5xnj4bn93vve8ntzwc",
+      "name": "Ross Island Aerial - 1945",
+      "description": "",
+      "file": "https://example.com/resources/acguba29wstyexf8uhxkvezn.jpg",
+      "original_file": "a2005-001-815-ross-island-bridge-west-approach-north-at-sw-kelly-1945.jpg",
+      "archived": false
     }
-]
-
+  ]
+}
 ```
 
 
@@ -119,7 +123,7 @@ The response body is an array containing a series of [project resource JSON obje
 POST /api/v1/organizations/{organization_slug}/projects/{project_slug}/resources/
 ```
 
-Use this endpoint and method to create a new project resource. 
+Use this endpoint and method to create a new project resource.
 
 **URL Parameters**
 
@@ -132,8 +136,8 @@ URL Parameter | Description
 
 To create a new resource, you'll need to provide the following properties:
 
-Property | Type | Required? | Description 
---- | --- | :---: | --- 
+Property | Type | Required? | Description
+--- | --- | :---: | ---
 `name` | `String` | x | The name of the file (e.g. Deed of Trust)
 `description` | `String` |  | A description of the file (e.g. The only deed we can find that has information relevant to the site.)
 `file` | `String` | x | URL to a hosted version of the file, likely on an Amazon server or something similar.
@@ -149,12 +153,12 @@ The response body contains a [project resource JSON object](#project-resource-ob
 
 ```json
 {
-    "id": "rtxixdb2a5weefmzmg7kzvgr",
-    "name": "Original Questionnaire",
-    "description": "This is the original questionnaire we were using; we updated it on 10.31.2016.",
-    "file": "https://example.com/minimum_cadasta_questionnaire.xlsx",
-    "original_file": "mimimum_cadasta_questionnaire.xlsx",
-    "archived": false
+  "id": "rtxixdb2a5weefmzmg7kzvgr",
+  "name": "Original Questionnaire",
+  "description": "This is the original questionnaire we were using; we updated it on 10.31.2016.",
+  "file": "https://example.com/minimum_cadasta_questionnaire.xlsx",
+  "original_file": "mimimum_cadasta_questionnaire.xlsx",
+  "archived": false
 }
 
 ```
@@ -178,7 +182,7 @@ The response body contains a [project resource JSON object](#project-resource-ob
 GET /api/v1/organizations/{organization_slug}/projects/{project_slug}/resources/{resource_id}/
 ```
 
-Use this method and endpoint to get a specific project resource. 
+Use this method and endpoint to get a specific project resource.
 
 **URL Parameters**
 
@@ -186,7 +190,7 @@ URL Parameter | Description
 ---|---
 `organization_slug` | The slug provided for the organization, which can be found by locating the organization in the [list of all organizations](#list-organizations)
 `project_slug` | The slug provided for the project, which can be found by [listing all of the projects in an organization](#list-all-projects).
-`resource_id` | The unique ID for the project resource. You can find this resource by [listing all of the resources for the project](#list-project-resources), finding the project you're looking for, and then copying the ID. 
+`resource_id` | The unique ID for the project resource. You can find this resource by [listing all of the resources for the project](#list-project-resources), finding the project you're looking for, and then copying the ID.
 
 
 **Response**
@@ -197,12 +201,12 @@ The response body contains a [project resource JSON object](#project-resource-ob
 
 ```json
 {
-    "id": "rtxixdb2a5weefmzmg7kzvgr",
-    "name": "Original Questionnaire",
-    "description": "This is the original questionnaire we were using; we updated it on 10.31.2016.",
-    "file": "https://example.com/minimum_cadasta_questionnaire.xlsx",
-    "original_file": "mimimum_cadasta_questionnaire.xlsx",
-    "archived": false
+  "id": "rtxixdb2a5weefmzmg7kzvgr",
+  "name": "Original Questionnaire",
+  "description": "This is the original questionnaire we were using; we updated it on 10.31.2016.",
+  "file": "https://example.com/minimum_cadasta_questionnaire.xlsx",
+  "original_file": "mimimum_cadasta_questionnaire.xlsx",
+  "archived": false
 }
 
 ```
@@ -233,14 +237,14 @@ URL Parameter | Description
 ---|---
 `organization_slug` | The slug provided for the organization, which can be found by locating the organization in the [list of all organizations](#list-organizations)
 `project_slug` | The slug provided for the project, which can be found by [listing all of the projects in an organization](#list-all-projects).
-`resource_id` | The unique ID for the project resource. You can find this resource by [listing all of the resources for the project](#list-project-resources), finding the project you're looking for, and then copying the ID. 
+`resource_id` | The unique ID for the project resource. You can find this resource by [listing all of the resources for the project](#list-project-resources), finding the project you're looking for, and then copying the ID.
 
 **Request Payload**
 
 Modify any value of the following fields of the project resource JSON object:
 
-Property | Type | Description 
---- | --- | --- 
+Property | Type | Description
+--- | --- | ---
 `name` | `String` | The name of the file (e.g. Deed of Trust)
 `description` | `String` | A description of the file (e.g. The only deed we can find that has information relevant to the site.)
 `file` | `String` | URL to a hosted version of the file, likely on an Amazon server or something similar.
@@ -256,12 +260,12 @@ The response body contains a [project resource JSON object](#project-resource-ob
 
 ```json
 {
-    "id": "rtxixdb2a5weefmzmg7kzvgr",
-    "name": "Original Questionnaire",
-    "description": "This is the original questionnaire we were using; we updated it on 10.31.2016.",
-    "file": "https://example.com/minimum_cadasta_questionnaire.xlsx",
-    "original_file": "mimimum_cadasta_questionnaire.xlsx",
-    "archived": false
+  "id": "rtxixdb2a5weefmzmg7kzvgr",
+  "name": "Original Questionnaire",
+  "description": "This is the original questionnaire we were using; we updated it on 10.31.2016.",
+  "file": "https://example.com/minimum_cadasta_questionnaire.xlsx",
+  "original_file": "mimimum_cadasta_questionnaire.xlsx",
+  "archived": false
 }
 
 ```
@@ -280,7 +284,7 @@ The response body contains a [project resource JSON object](#project-resource-ob
 
 ## Spatial Resources
 
-Sometimes your resources may be in the form of an XML file (usually converted from a GPS Exchange Format, or .gpx). You can use this API to return all of the GPS coordinates logged in the file. 
+Sometimes your resources may be in the form of an XML file (usually converted from a GPS Exchange Format, or .gpx). You can use this API to return all of the GPS coordinates logged in the file.
 
 Spatial resources can be accessed using endpoints that start like this:
 
@@ -298,12 +302,12 @@ Use this endpoint to return all of the spatial resources in a given project, alo
 
 **Response**
 
-The response is an array of [project resource JSON objects](#project-resource-object), each with an additional `spatial_resources` object field. 
+The response is an array of [project resource JSON objects](#project-resource-object), each with an additional `spatial_resources` object field.
 
 The `spatial_resources` object has the following properties:
 
-Property | Type | Description 
---- | --- | --- 
+Property | Type | Description
+--- | --- | ---
 `id` | `String` | A unique ID automatically generated for the file.
 `name` | `String` | The name of the file (e.g. Waypoints)
 `time` | `String` | The date and time that the file was uploaded.
@@ -311,15 +315,15 @@ Property | Type | Description
 
 The `geom` object has the following properties:
 
-Property | Type | Description 
---- | --- | --- 
+Property | Type | Description
+--- | --- | ---
 `geometries` | `Array` | Contains an array of all the coordinates and type of coordinates for a particular spatial resource.
 `type` | `String` | The type of coordinate collection (usually listed as `GeometryCollection`). (See the `geometries` table below.)
 
 The objects in `geometries` each have the following properties:
 
-Property | Type | Description 
---- | --- | --- 
+Property | Type | Description
+--- | --- | ---
 `coordinates` | `Array` | Contains the latitude and longitude coordinates for each point.
 `type` | `String` | The type of coordinate (usually set to `Point`).
 
@@ -327,104 +331,105 @@ Property | Type | Description
 #### Example Response
 
 ```json
-[
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
     {
-        "id": "casjsraq9hmqaxkuh6scmue2",
-        "name": "Waypoints",
-        "description": "",
-        "original_file": "Example (Waypoints_26-NOV-15).xml",
-        "archived": false,
-        "spatial_resources": [
-            {
-                "id": "ancghgmzbk8wi92fgt9yszdt",
-                "name": "waypoints",
-                "time": "2016-11-08T17:54:43.903091Z",
-                "geom": {
-                    "geometries": [
-                        {
-                            "coordinates": [
-                                3.35652,
-                                6.464177
-                            ],
-                            "type": "Point"
-                        },
-                        {
-                            "coordinates": [
-                                3.356425,
-                                6.462206
-                            ],
-                            "type": "Point"
-                        },
-                        {
-                            "coordinates": [
-                                3.35627,
-                                6.46216
-                            ],
-                            "type": "Point"
-                        },
-                        {
-                            "coordinates": [
-                                3.356593,
-                                6.462282
-                            ],
-                            "type": "Point"
-                        }
-                    ],
-                    "type": "GeometryCollection"
-                }
-            }
-        ]
+      "id": "casjsraq9hmqaxkuh6scmue2",
+      "name": "Waypoints",
+      "description": "",
+      "original_file": "Example (Waypoints_26-NOV-15).xml",
+      "archived": false,
+      "spatial_resources": [
+        {
+          "id": "ancghgmzbk8wi92fgt9yszdt",
+          "name": "waypoints",
+          "time": "2016-11-08T17:54:43.903091Z",
+          "geom": {
+            "geometries": [
+              {
+                "coordinates": [
+                  3.35652,
+                  6.464177
+                ],
+                "type": "Point"
+              },
+              {
+                "coordinates": [
+                  3.356425,
+                  6.462206
+                ],
+                "type": "Point"
+              },
+              {
+                "coordinates": [
+                  3.35627,
+                  6.46216
+                ],
+                "type": "Point"
+              },
+              {
+                "coordinates": [
+                  3.356593,
+                  6.462282
+                ],
+                "type": "Point"
+              }
+            ],
+            "type": "GeometryCollection"
+          }
+        }
+      ]
     },
     {
-        "id": "uqzbwpbeiyejfafx8t7nadcr",
-        "name": "Waypoints 2",
-        "description": "",
-        "original_file": "Example 2 (Waypoints_26-NOV-15).xml",
-        "archived": false,
-        "spatial_resources": [
-            {
-                "id": "ryqfpbk6jmmrjshq7t7yguij",
-                "name": "waypoints",
-                "time": "2016-11-08T18:09:39.076667Z",
-                "geom": {
-                    "geometries": [
-                        {
-                            "coordinates": [
-                                4.35652,
-                                7.464177
-                            ],
-                            "type": "Point"
-                        },
-                        {
-                            "coordinates": [
-                                3.356389,
-                                6.462436
-                            ],
-                            "type": "Point"
-                        },
-                        {
-                            "coordinates": [
-                                4.356569,
-                                7.462434
-                            ],
-                            "type": "Point"
-                        },
-                        {
-                            "coordinates": [
-                                4.356593,
-                                7.462282
-                            ],
-                            "type": "Point"
-                        }
-                    ],
-                    "type": "GeometryCollection"
-                }
-            }
-        ]
+      "id": "uqzbwpbeiyejfafx8t7nadcr",
+      "name": "Waypoints 2",
+      "description": "",
+      "original_file": "Example 2 (Waypoints_26-NOV-15).xml",
+      "archived": false,
+      "spatial_resources": [
+        {
+          "id": "ryqfpbk6jmmrjshq7t7yguij",
+          "name": "waypoints",
+          "time": "2016-11-08T18:09:39.076667Z",
+          "geom": {
+            "geometries": [
+              {
+                "coordinates": [
+                  4.35652,
+                  7.464177
+                ],
+                "type": "Point"
+              },
+              {
+                "coordinates": [
+                  3.356389,
+                  6.462436
+                ],
+                "type": "Point"
+              },
+              {
+                "coordinates": [
+                  4.356569,
+                  7.462434
+                ],
+                "type": "Point"
+              },
+              {
+                "coordinates": [
+                  4.356593,
+                  7.462282
+                ],
+                "type": "Point"
+              }
+            ],
+            "type": "GeometryCollection"
+          }
+        }
+      ]
     }
-]
-
+  ]
+}
 ```
-
-
-


### PR DESCRIPTION
Add documentation to support API Pagination.  This includes:

* Updating examples to demonstrate pagination
* Adding a quick description of how pagination works with our API

Additionally, there were some small cleanups done along the way:

* Trailing spaces removed
* Indentation unified to `2` spaces (some examples were indented to `4` spaces)
* The [example for listing project users](https://github.com/Cadasta/api-docs/compare/master...support-pagination#diff-0454c2585c13cecd7e06b65fbc95ad02R472) seemed to be incorrect
