### PR TITLE
Rm confusing Request Payload description, point to prior docs for clarification

### DIFF
--- a/content/06-records.md
+++ b/content/06-records.md
@@ -221,15 +221,11 @@ The response body is a GeoJSON feature collection of multiple [project location 
 POST /api/v1/organizations/{organization_slug}/projects/{project_slug}/spatial/
 ```
 
-Use this method to create a new spatial unit / project location.
+Use this method to create a new spatial unit / project location. Each spatial unit should represent a single feature (rather than a feature collection).
 
 **Request Payload**
 
-Property | Type | Required? | Description
---- | --- | :---: | ---
-`geometry` | `Object` | x | A <a href="https://en.wikipedia.org/wiki/GeoJSON#Geometries" target="_blank"> GeoJSON geometry</a>) defining the geographic coordinates of the location.
-`type` | `String` | x | This refers to the possible land `types` that the location could be (e.g. `PA` = Parcel). See the **Land `type` Abbreviations**  table above for more information.
-`attributes` | `Array` |  | An array of different attributes for the property.
+The endpoint expects a <a href="https://en.wikipedia.org/wiki/GeoJSON#Geometries" target="_blank"> GeoJSON geometry</a>) defining the geographic coordinates of the location.  The location's metadata should be encoded in its `properties` attribute. For more information, see the above [Spatial Unit JSON Object documentation](##spatial-unit-json-object).
 
 
 **Response**

--- a/content/06-records.md
+++ b/content/06-records.md
@@ -225,7 +225,13 @@ Use this method to create a new spatial unit / project location. Each spatial un
 
 **Request Payload**
 
-The endpoint expects a <a href="https://en.wikipedia.org/wiki/GeoJSON#Geometries" target="_blank"> GeoJSON geometry</a>) defining the geographic coordinates of the location.  The location's metadata should be encoded in its `properties` attribute. For more information, see the above [Spatial Unit JSON Object documentation](##spatial-unit-json-object).
+Request object should formatted as a <a href="https://en.wikipedia.org/wiki/GeoJSON" target="_blank"> GeoJSON object</a>), as described in the [Spatial Unit JSON Object documentation](##spatial-unit-json-object).
+
+Property | Type | Required? | Description
+--- | --- | :---: | ---
+`geometry` | `Object` | x | A <a href="https://en.wikipedia.org/wiki/GeoJSON#Geometries" target="_blank"> GeoJSON Feature's geometry attribute</a>)defining the geographic coordinates of the location.
+`properties.type` | `String` | x | This refers to the possible land `types` that the location could be (e.g. `PA` = Parcel). See the **Land `type` Abbreviations**  table above for more information.
+`properties.attributes` | `Array` |  | An array of different attributes for the property.
 
 
 **Response**


### PR DESCRIPTION
The current docs regarding creating `SpatialUnit` instances seems to suggest that the GeoJSON data should be put behind the `geometry` key of the request payload. In actuality, our API expects that the request payload be the GeoJSON, with the additional `SpatialUnit` properties being placed in the `properties` property of the GeoJSON object.  This is as described in the "Spatial Unit JSON Object" section of the docs.  I think it's best to just point to that documentation rather than rewriting it in the "Creating Spatial Units" section.